### PR TITLE
Add privacy policy page

### DIFF
--- a/privacy.html
+++ b/privacy.html
@@ -1,0 +1,172 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Privacy Policy - Workout Planner</title>
+    <style>
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+            line-height: 1.6;
+            color: #e0e0e0;
+            background-color: #1a1a1a;
+            padding: 20px;
+        }
+
+        .container {
+            max-width: 800px;
+            margin: 0 auto;
+            background-color: #242424;
+            padding: 40px;
+            border-radius: 8px;
+            box-shadow: 0 2px 10px rgba(0, 0, 0, 0.3);
+        }
+
+        h1 {
+            color: #8bc34a;
+            margin-bottom: 10px;
+            font-size: 2em;
+        }
+
+        h2 {
+            color: #8bc34a;
+            margin-top: 30px;
+            margin-bottom: 15px;
+            font-size: 1.5em;
+        }
+
+        p {
+            margin-bottom: 15px;
+            color: #b0b0b0;
+        }
+
+        ul {
+            margin-left: 20px;
+            margin-bottom: 15px;
+            color: #b0b0b0;
+        }
+
+        li {
+            margin-bottom: 8px;
+        }
+
+        .last-updated {
+            color: #888;
+            font-size: 0.9em;
+            margin-bottom: 30px;
+        }
+
+        a {
+            color: #646cff;
+            text-decoration: none;
+        }
+
+        a:hover {
+            text-decoration: underline;
+        }
+
+        .highlight {
+            background-color: #2d5016;
+            padding: 15px;
+            border-radius: 5px;
+            margin: 20px 0;
+            border-left: 4px solid #8bc34a;
+        }
+
+        @media (max-width: 768px) {
+            .container {
+                padding: 20px;
+            }
+
+            h1 {
+                font-size: 1.5em;
+            }
+
+            h2 {
+                font-size: 1.2em;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>Privacy Policy</h1>
+        <p class="last-updated">Last Updated: February 3, 2026</p>
+
+        <div class="highlight">
+            <p><strong>Summary:</strong> Workout Planner is a client-side web application that helps you view and organize your workout plans from Google Sheets. We do not collect, store, or transmit your personal data to any servers. All data stays on your device.</p>
+        </div>
+
+        <h2>1. Information We Access</h2>
+        <p>Workout Planner requires access to:</p>
+        <ul>
+            <li><strong>Google Account Authentication:</strong> To verify your identity and access your Google Sheets</li>
+            <li><strong>Google Sheets Data:</strong> Read-only access to specific Google Sheets you choose to open</li>
+        </ul>
+
+        <h2>2. How We Use Your Information</h2>
+        <p>Your information is used exclusively for:</p>
+        <ul>
+            <li>Authenticating your Google account</li>
+            <li>Reading workout data from your selected Google Sheets</li>
+            <li>Displaying your workout plans in an organized calendar interface</li>
+            <li>Storing your preferences locally on your device (sheet history, authentication tokens)</li>
+        </ul>
+
+        <h2>3. Data Storage</h2>
+        <p>All data is stored locally in your browser using localStorage:</p>
+        <ul>
+            <li><strong>Authentication Tokens:</strong> Stored to maintain your login session</li>
+            <li><strong>Sheet History:</strong> Sheet IDs, titles, and access timestamps for quick access</li>
+            <li><strong>User Preferences:</strong> Selected dates and view modes</li>
+        </ul>
+        <p><strong>Important:</strong> No data is transmitted to or stored on our servers. Everything remains on your device.</p>
+
+        <h2>4. Third-Party Services</h2>
+        <p>Workout Planner uses the following Google services:</p>
+        <ul>
+            <li><strong>Google OAuth 2.0:</strong> For secure authentication</li>
+            <li><strong>Google Sheets API:</strong> For read-only access to your workout data</li>
+        </ul>
+        <p>These services are governed by <a href="https://policies.google.com/privacy" target="_blank" rel="noopener noreferrer">Google's Privacy Policy</a>.</p>
+
+        <h2>5. Data Security</h2>
+        <p>We take security seriously:</p>
+        <ul>
+            <li>All connections use HTTPS encryption</li>
+            <li>Authentication tokens are stored securely in your browser</li>
+            <li>We only request read-only access to your Google Sheets</li>
+            <li>No server-side data storage or processing</li>
+        </ul>
+
+        <h2>6. Your Rights</h2>
+        <p>You have full control over your data:</p>
+        <ul>
+            <li><strong>Access:</strong> All your data is visible in your browser's localStorage</li>
+            <li><strong>Deletion:</strong> Clear your browser's localStorage or use the "Delete" buttons in the app to remove sheet history</li>
+            <li><strong>Revoke Access:</strong> Disconnect the app from your Google account at any time via <a href="https://myaccount.google.com/permissions" target="_blank" rel="noopener noreferrer">Google Account Permissions</a></li>
+        </ul>
+
+        <h2>7. Cookies and Tracking</h2>
+        <p>Workout Planner does not use cookies or any tracking mechanisms. We do not use analytics, advertising, or third-party tracking tools.</p>
+
+        <h2>8. Children's Privacy</h2>
+        <p>Workout Planner does not knowingly collect information from children under 13. If you are under 13, please do not use this application without parental consent.</p>
+
+        <h2>9. Changes to This Policy</h2>
+        <p>We may update this privacy policy from time to time. The "Last Updated" date at the top of this page indicates when the policy was last revised.</p>
+
+        <h2>10. Open Source</h2>
+        <p>Workout Planner is open source. You can review the complete source code and verify our privacy claims on <a href="https://github.com/fopina/xsibas-workouts" target="_blank" rel="noopener noreferrer">GitHub</a>.</p>
+
+        <h2>11. Contact</h2>
+        <p>If you have questions about this privacy policy or the application, please open an issue on our <a href="https://github.com/fopina/xsibas-workouts/issues" target="_blank" rel="noopener noreferrer">GitHub repository</a>.</p>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
Add a self-contained privacy policy HTML page that can be hosted independently.

## Changes
- Create `privacy.html` with embedded CSS
- Dark theme matching app design
- Comprehensive privacy policy covering data access, storage, and security
- Mobile-responsive layout
- Links to Google Privacy Policy and GitHub repository

## Features
- No external dependencies (all CSS embedded)
- Explains client-side only data storage
- No tracking or cookies policy
- User rights and data control information
- Open source transparency

🤖 Generated with [Claude Code](https://claude.com/claude-code)