### PR TITLE
Switch to drive.file scope for enhanced privacy

### DIFF
--- a/src/components/auth.jsx
+++ b/src/components/auth.jsx
@@ -23,7 +23,7 @@ const Auth = ({ onAuthChange }) => {
         console.log('Client ID:', import.meta.env.VITE_GOOGLE_CLIENT_ID);
         const client = window.google.accounts.oauth2.initTokenClient({
           client_id: import.meta.env.VITE_GOOGLE_CLIENT_ID,
-          scope: 'https://www.googleapis.com/auth/spreadsheets.readonly',
+          scope: 'https://www.googleapis.com/auth/drive.file',
           callback: (tokenResponse) => {
             console.log('Token response received:', tokenResponse);
             if (tokenResponse && tokenResponse.access_token) {


### PR DESCRIPTION
## Summary
- Changed OAuth scope from `https://www.googleapis.com/auth/spreadsheets.readonly` to `https://www.googleapis.com/auth/drive.file`
- This more restrictive scope only grants access to files the user has explicitly opened with the app
- Improves privacy protection without affecting functionality

## Technical Details
The `drive.file` scope is more privacy-focused than `spreadsheets.readonly`:
- **Before**: App could access all spreadsheets the user owns
- **After**: App can only access spreadsheets the user has explicitly opened via URL

## Test plan
- [x] Update OAuth consent screen in Google Cloud Console to use the new scope
- [x] Test login flow and verify consent screen shows the correct permissions
- [x] Verify spreadsheet data loads correctly with the new scope
- [ ] Check that existing logged-in users need to re-authenticate with new permissions

🤖 Generated with [Claude Code](https://claude.com/claude-code)