### PR TITLE
Force OAuth consent screen on every login

### DIFF
--- a/src/components/auth.jsx
+++ b/src/components/auth.jsx
@@ -57,7 +57,10 @@ const Auth = ({ onAuthChange }) => {
       // Prompt the user to select a Google Account and ask for consent to share their data
       // when establishing a new session.
       console.log('Requesting access token...');
-      tokenClient.requestAccessToken();
+      tokenClient.requestAccessToken({
+        prompt: 'consent',
+        include_granted_scopes: false
+      });
     } else {
       console.error('Token client not initialized');
     }


### PR DESCRIPTION
## Summary
- Add `prompt: 'consent'` to force consent screen to appear every time
- Add `include_granted_scopes: false` to prevent adding previously granted scopes

## Purpose
This ensures that when users log in, they'll always see the consent screen with the current `drive.file` scope, resetting any previously granted permissions. Useful for testing and ensuring proper scope authorization.

## Changes
- Modified `src/components/auth.jsx` to add consent parameters to `requestAccessToken()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)