### PR TITLE
Handle invalid OAuth token by falling back to public sheet access

### DIFF
--- a/src/components/workoutLog.jsx
+++ b/src/components/workoutLog.jsx
@@ -134,15 +134,16 @@ const WorkoutLog = ({ accessToken, sheetId, onSheetTitleLoaded, onAuthRequired }
     );
   };
 
-  useEffect(() => {
-    const apiKey = import.meta.env.VITE_GOOGLE_API_KEY;
-    const hasApiKey = !!apiKey && apiKey !== 'YOUR_API_KEY_HERE';
+  const formatApiErrorDebug = (err) => {
+    const errorMessage = err?.result?.error?.message || err?.message || 'Unknown error';
+    const errorStatus = err?.result?.error?.status || err?.status || 'UNKNOWN_STATUS';
+    const errorCode = err?.result?.error?.code || err?.code || 'UNKNOWN_CODE';
+    return `[debug status=${errorStatus} code=${errorCode} message="${errorMessage}"]`;
+  };
 
-    // Need either OAuth token or API key to proceed
-    if (!accessToken && !hasApiKey) {
-      setError('Please log in to view your workout plan.');
-      return;
-    }
+  useEffect(() => {
+    const apiKey = (import.meta.env.VITE_GOOGLE_API_KEY || '').trim();
+    const hasApiKey = !!apiKey && apiKey !== 'YOUR_API_KEY_HERE' && apiKey !== 'your_api_key_here';
 
     const fetchSheetData = async () => {
       setLoading(true);
@@ -175,6 +176,8 @@ const WorkoutLog = ({ accessToken, sheetId, onSheetTitleLoaded, onAuthRequired }
         }
 
         const fetchWithCurrentAuthMode = async () => {
+          const requestOptions = currentAuthMode === 'anonymous' && hasApiKey ? { key: apiKey } : {};
+
           // Configure authentication mode for this attempt
           if (currentAuthMode === 'token') {
             gapi.client.setToken({ access_token: accessToken });
@@ -189,7 +192,7 @@ const WorkoutLog = ({ accessToken, sheetId, onSheetTitleLoaded, onAuthRequired }
 
           // 2.5. Validate spreadsheet schema
           try {
-            const validation = await validateSpreadsheetSchema(gapi, sheetId);
+            const validation = await validateSpreadsheetSchema(gapi, sheetId, requestOptions);
             if (!validation.valid) {
               setError(formatValidationErrors(validation.errors));
               setLoading(false);
@@ -204,7 +207,8 @@ const WorkoutLog = ({ accessToken, sheetId, onSheetTitleLoaded, onAuthRequired }
           try {
             const metadataResponse = await gapi.client.sheets.spreadsheets.get({
               spreadsheetId: sheetId,
-              fields: 'properties.title'
+              fields: 'properties.title',
+              ...requestOptions
             });
             const sheetTitle = metadataResponse.result.properties?.title;
             if (sheetTitle && onSheetTitleLoaded) {
@@ -218,6 +222,7 @@ const WorkoutLog = ({ accessToken, sheetId, onSheetTitleLoaded, onAuthRequired }
           const exercisesResponse = await gapi.client.sheets.spreadsheets.values.get({
             spreadsheetId: sheetId,
             range: 'Exercises!A:D',
+            ...requestOptions
           });
 
           const exercisesData = exercisesResponse.result.values;
@@ -244,6 +249,7 @@ const WorkoutLog = ({ accessToken, sheetId, onSheetTitleLoaded, onAuthRequired }
           const workoutResponse = await gapi.client.sheets.spreadsheets.values.get({
             spreadsheetId: sheetId,
             range: 'WorkoutLog!A:Z',
+            ...requestOptions
           });
 
           const data = workoutResponse.result.values;
@@ -283,23 +289,24 @@ const WorkoutLog = ({ accessToken, sheetId, onSheetTitleLoaded, onAuthRequired }
         const errorMessage = err.result?.error?.message || err.message || '';
         const errorStatus = err.result?.error?.status || err.status || '';
         const errorCode = err.result?.error?.code || err.code || 0;
+        const debugInfo = formatApiErrorDebug(err);
 
         // Check for permission errors when in anonymous mode
         if ((errorStatus === 'PERMISSION_DENIED' || errorCode === 403) && currentAuthMode === 'anonymous') {
-          setError('This sheet is private. Please log in to view it.');
+          setError(`This sheet is private. Please log in to view it. ${debugInfo}`);
           if (onAuthRequired) onAuthRequired();
         }
         // Check for authentication errors with token
         else if (errorStatus === 'UNAUTHENTICATED' || errorMessage.includes('Invalid Credentials') || errorMessage.includes('invalid authentication')) {
-          setError('Login expired. Login again');
+          setError(`Login expired. Login again ${debugInfo}`);
           if (onAuthRequired) onAuthRequired();
         }
         // Check for permission errors when authenticated
         else if ((errorStatus === 'PERMISSION_DENIED' || errorCode === 403) && accessToken) {
-          setError(`You don't have permission to access this sheet. Make sure it's shared with your Google account.`);
+          setError(`You don't have permission to access this sheet. Make sure it's shared with your Google account. ${debugInfo}`);
         }
         else {
-          setError(`Error fetching workout data: ${errorMessage}`);
+          setError(`Error fetching workout data: ${errorMessage} ${debugInfo}`);
         }
       } finally {
         setLoading(false);

--- a/src/components/workoutLog.jsx
+++ b/src/components/workoutLog.jsx
@@ -110,11 +110,25 @@ const WorkoutLog = ({ accessToken, sheetId, onSheetTitleLoaded, onAuthRequired }
     return null;
   };
 
+  const isTokenAuthError = (err) => {
+    const errorMessage = (err?.result?.error?.message || err?.message || '').toLowerCase();
+    const errorStatus = err?.result?.error?.status || err?.status || '';
+    const errorCode = err?.result?.error?.code || err?.code || 0;
+
+    return (
+      errorStatus === 'UNAUTHENTICATED' ||
+      errorCode === 401 ||
+      errorMessage.includes('invalid credentials') ||
+      errorMessage.includes('invalid authentication')
+    );
+  };
+
   useEffect(() => {
     const apiKey = import.meta.env.VITE_GOOGLE_API_KEY;
+    const hasApiKey = !!apiKey && apiKey !== 'YOUR_API_KEY_HERE';
 
     // Need either OAuth token or API key to proceed
-    if (!accessToken && (!apiKey || apiKey === 'YOUR_API_KEY_HERE')) {
+    if (!accessToken && !hasApiKey) {
       setError('Please log in to view your workout plan.');
       return;
     }
@@ -122,6 +136,7 @@ const WorkoutLog = ({ accessToken, sheetId, onSheetTitleLoaded, onAuthRequired }
     const fetchSheetData = async () => {
       setLoading(true);
       setError(null);
+      let currentAuthMode = accessToken ? 'token' : 'anonymous';
       try {
         // Wait for gapi.client to be initialized
         await new Promise((resolve) => {
@@ -132,13 +147,6 @@ const WorkoutLog = ({ accessToken, sheetId, onSheetTitleLoaded, onAuthRequired }
             }
           }, 100);
         });
-
-        // 1. Configure authentication - use OAuth token if available, otherwise API key
-        if (accessToken) {
-          gapi.client.setToken({ access_token: accessToken });
-        } else if (apiKey) {
-          gapi.client.setApiKey(apiKey);
-        }
 
         // 2. Load the Sheets API discovery document
         try {
@@ -155,82 +163,107 @@ const WorkoutLog = ({ accessToken, sheetId, onSheetTitleLoaded, onAuthRequired }
           return;
         }
 
-        // 2.5. Validate spreadsheet schema
-        try {
-          const validation = await validateSpreadsheetSchema(gapi, sheetId);
-          if (!validation.valid) {
-            setError(formatValidationErrors(validation.errors));
-            setLoading(false);
-            return;
-          }
-        } catch (err) {
-          // Let auth/permission errors from validation bubble up to main error handler
-          throw err;
-        }
-
-        // 3. Fetch spreadsheet metadata to get title
-        try {
-          const metadataResponse = await gapi.client.sheets.spreadsheets.get({
-            spreadsheetId: sheetId,
-            fields: 'properties.title'
-          });
-          const sheetTitle = metadataResponse.result.properties?.title;
-          if (sheetTitle && onSheetTitleLoaded) {
-            onSheetTitleLoaded(sheetId, sheetTitle);
-          }
-        } catch (err) {
-          console.warn('Could not fetch sheet title:', err);
-        }
-
-        // 5. Fetch Exercises tab to get video link mapping
-        const exercisesResponse = await gapi.client.sheets.spreadsheets.values.get({
-          spreadsheetId: sheetId,
-          range: 'Exercises!A:D',
-        });
-
-        const exercisesData = exercisesResponse.result.values;
-        const videoMap = {};
-        if (exercisesData && exercisesData.length > 1) {
-          // Assuming row 0 is headers, find the Exercise and VideoLink columns
-          const exerciseHeaders = exercisesData[0];
-          const exerciseNameIndex = exerciseHeaders.indexOf('Exercise');
-          const videoLinkIndex = exerciseHeaders.indexOf('VideoLink');
-
-          if (exerciseNameIndex !== -1 && videoLinkIndex !== -1) {
-            exercisesData.slice(1).forEach(row => {
-              const exerciseName = row[exerciseNameIndex];
-              const videoLink = row[videoLinkIndex];
-              if (exerciseName && videoLink) {
-                videoMap[exerciseName] = videoLink;
-              }
-            });
-          }
-        }
-        setExerciseVideoMap(videoMap);
-
-        // 6. Fetch WorkoutLog data
-        const workoutResponse = await gapi.client.sheets.spreadsheets.values.get({
-          spreadsheetId: sheetId,
-          range: 'WorkoutLog!A:Z',
-        });
-
-        const data = workoutResponse.result.values;
-        if (data && data.length > 0) {
-          const headers = data[0];
-          const formattedData = data.slice(1).map(row => {
-            const workout = {};
-            headers.forEach((header, index) => {
-              workout[header] = row[index] || ''; // Ensure empty cells are handled
-            });
-            // Ensure every workout has a Notes field even if column doesn't exist
-            if (!('Notes' in workout)) {
-              workout.Notes = '';
+        const fetchWithCurrentAuthMode = async () => {
+          // Configure authentication mode for this attempt
+          if (currentAuthMode === 'token') {
+            gapi.client.setToken({ access_token: accessToken });
+          } else {
+            gapi.client.setToken(null);
+            if (hasApiKey) {
+              gapi.client.setApiKey(apiKey);
             }
-            return workout;
+          }
+
+          // 2.5. Validate spreadsheet schema
+          try {
+            const validation = await validateSpreadsheetSchema(gapi, sheetId);
+            if (!validation.valid) {
+              setError(formatValidationErrors(validation.errors));
+              setLoading(false);
+              return;
+            }
+          } catch (err) {
+            // Let auth/permission errors from validation bubble up to main error handler
+            throw err;
+          }
+
+          // 3. Fetch spreadsheet metadata to get title
+          try {
+            const metadataResponse = await gapi.client.sheets.spreadsheets.get({
+              spreadsheetId: sheetId,
+              fields: 'properties.title'
+            });
+            const sheetTitle = metadataResponse.result.properties?.title;
+            if (sheetTitle && onSheetTitleLoaded) {
+              onSheetTitleLoaded(sheetId, sheetTitle);
+            }
+          } catch (err) {
+            console.warn('Could not fetch sheet title:', err);
+          }
+
+          // 5. Fetch Exercises tab to get video link mapping
+          const exercisesResponse = await gapi.client.sheets.spreadsheets.values.get({
+            spreadsheetId: sheetId,
+            range: 'Exercises!A:D',
           });
-          setWorkouts(formattedData);
-        } else {
-          setError('No data found in sheet.');
+
+          const exercisesData = exercisesResponse.result.values;
+          const videoMap = {};
+          if (exercisesData && exercisesData.length > 1) {
+            // Assuming row 0 is headers, find the Exercise and VideoLink columns
+            const exerciseHeaders = exercisesData[0];
+            const exerciseNameIndex = exerciseHeaders.indexOf('Exercise');
+            const videoLinkIndex = exerciseHeaders.indexOf('VideoLink');
+
+            if (exerciseNameIndex !== -1 && videoLinkIndex !== -1) {
+              exercisesData.slice(1).forEach(row => {
+                const exerciseName = row[exerciseNameIndex];
+                const videoLink = row[videoLinkIndex];
+                if (exerciseName && videoLink) {
+                  videoMap[exerciseName] = videoLink;
+                }
+              });
+            }
+          }
+          setExerciseVideoMap(videoMap);
+
+          // 6. Fetch WorkoutLog data
+          const workoutResponse = await gapi.client.sheets.spreadsheets.values.get({
+            spreadsheetId: sheetId,
+            range: 'WorkoutLog!A:Z',
+          });
+
+          const data = workoutResponse.result.values;
+          if (data && data.length > 0) {
+            const headers = data[0];
+            const formattedData = data.slice(1).map(row => {
+              const workout = {};
+              headers.forEach((header, index) => {
+                workout[header] = row[index] || ''; // Ensure empty cells are handled
+              });
+              // Ensure every workout has a Notes field even if column doesn't exist
+              if (!('Notes' in workout)) {
+                workout.Notes = '';
+              }
+              return workout;
+            });
+            setWorkouts(formattedData);
+          } else {
+            setError('No data found in sheet.');
+          }
+        };
+
+        try {
+          await fetchWithCurrentAuthMode();
+        } catch (err) {
+          // Invalid/expired token should not block access to public sheets:
+          // retry once anonymously when API key is available.
+          if (currentAuthMode === 'token' && hasApiKey && isTokenAuthError(err)) {
+            currentAuthMode = 'anonymous';
+            await fetchWithCurrentAuthMode();
+          } else {
+            throw err;
+          }
         }
       } catch (err) {
         console.error("Error fetching sheet data:", err);
@@ -239,7 +272,7 @@ const WorkoutLog = ({ accessToken, sheetId, onSheetTitleLoaded, onAuthRequired }
         const errorCode = err.result?.error?.code || err.code || 0;
 
         // Check for permission errors when in anonymous mode
-        if ((errorStatus === 'PERMISSION_DENIED' || errorCode === 403) && !accessToken) {
+        if ((errorStatus === 'PERMISSION_DENIED' || errorCode === 403) && currentAuthMode === 'anonymous') {
           setError('This sheet is private. Please log in to view it.');
           if (onAuthRequired) onAuthRequired();
         }

--- a/src/components/workoutLog.jsx
+++ b/src/components/workoutLog.jsx
@@ -123,6 +123,17 @@ const WorkoutLog = ({ accessToken, sheetId, onSheetTitleLoaded, onAuthRequired }
     );
   };
 
+  const shouldRetryAnonymously = (err) => {
+    const errorStatus = err?.result?.error?.status || err?.status || '';
+    const errorCode = err?.result?.error?.code || err?.code || 0;
+
+    return (
+      isTokenAuthError(err) ||
+      errorStatus === 'PERMISSION_DENIED' ||
+      errorCode === 403
+    );
+  };
+
   useEffect(() => {
     const apiKey = import.meta.env.VITE_GOOGLE_API_KEY;
     const hasApiKey = !!apiKey && apiKey !== 'YOUR_API_KEY_HERE';
@@ -169,6 +180,8 @@ const WorkoutLog = ({ accessToken, sheetId, onSheetTitleLoaded, onAuthRequired }
             gapi.client.setToken({ access_token: accessToken });
           } else {
             gapi.client.setToken(null);
+            // Some gapi versions can keep stale auth in memory; clear token aggressively.
+            gapi.client.setToken({});
             if (hasApiKey) {
               gapi.client.setApiKey(apiKey);
             }
@@ -258,7 +271,7 @@ const WorkoutLog = ({ accessToken, sheetId, onSheetTitleLoaded, onAuthRequired }
         } catch (err) {
           // Invalid/expired token should not block access to public sheets:
           // retry once anonymously when API key is available.
-          if (currentAuthMode === 'token' && hasApiKey && isTokenAuthError(err)) {
+          if (currentAuthMode === 'token' && hasApiKey && shouldRetryAnonymously(err)) {
             currentAuthMode = 'anonymous';
             await fetchWithCurrentAuthMode();
           } else {

--- a/src/utils/schemaValidator.js
+++ b/src/utils/schemaValidator.js
@@ -15,16 +15,18 @@ const EXPECTED_SCHEMA = {
  * Validates the spreadsheet schema
  * @param {Object} gapi - Google API client
  * @param {string} sheetId - Spreadsheet ID
+ * @param {Object} requestOptions - Extra request params (e.g. { key: apiKey } for anonymous access)
  * @returns {Promise<{valid: boolean, errors: string[]}>}
  */
-export async function validateSpreadsheetSchema(gapi, sheetId) {
+export async function validateSpreadsheetSchema(gapi, sheetId, requestOptions = {}) {
   const errors = [];
 
   // 1. Get spreadsheet metadata to check sheet names
   // This is outside try/catch to let auth/permission errors bubble up
   const metadataResponse = await gapi.client.sheets.spreadsheets.get({
     spreadsheetId: sheetId,
-    fields: 'sheets.properties'
+    fields: 'sheets.properties',
+    ...requestOptions
   });
 
   const sheets = metadataResponse.result.sheets || [];
@@ -47,7 +49,8 @@ export async function validateSpreadsheetSchema(gapi, sheetId) {
     try {
       const headerResponse = await gapi.client.sheets.spreadsheets.values.get({
         spreadsheetId: sheetId,
-        range: `${sheetName}!1:1`
+        range: `${sheetName}!1:1`,
+        ...requestOptions
       });
 
       const actualHeaders = headerResponse.result.values?.[0] || [];


### PR DESCRIPTION
## Summary
- retry sheet fetch anonymously (API key mode) when token-authenticated request fails with UNAUTHENTICATED/invalid credentials
- keep existing behavior for private sheets (prompt login when anonymous access is denied)
- prevent expired localStorage token from blocking public sheet loads

## Validation
- npm run build