### PR TITLE
Add GSheets shortcuts and exercise metadata in workout view

### DIFF
--- a/src/app.jsx
+++ b/src/app.jsx
@@ -494,7 +494,13 @@ export function App() {
             </button>
           </form>
           <p style={{ color: '#666', fontSize: '0.8em', marginTop: '1em', wordBreak: 'break-all' }}>
-            Example: https://docs.google.com/spreadsheets/d/1VB5ncABedr88ucuxfE6UdLv9OFKo0foTSJD0Qel6OtE/edit
+            Demo:{' '}
+            <a
+              href="/workout?sheet=1VB5ncABedr88ucuxfE6UdLv9OFKo0foTSJD0Qel6OtE&date=2026-02-11"
+              style={{ color: '#8bc34a', textDecoration: 'none' }}
+            >
+              /workout?sheet=1VB5ncABedr88ucuxfE6UdLv9OFKo0foTSJD0Qel6OtE&date=2026-02-11
+            </a>
           </p>
         </div>
       </div>

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -239,6 +239,10 @@ export function App() {
     });
   };
 
+  const openInGoogleSheets = (id) => {
+    window.open(`https://docs.google.com/spreadsheets/d/${id}`, '_blank', 'noopener,noreferrer');
+  };
+
   const SheetSelector = () => {
     const history = getSheetsHistory();
     const currentSheetData = sheetId ? history[sheetId] : null;
@@ -277,20 +281,36 @@ export function App() {
               <p style={{ margin: 0, fontSize: '0.9em', color: '#aaa' }}>
                 Currently open:
               </p>
-              <button
-                onClick={unloadSheet}
-                style={{
-                  padding: '0.3em 0.6em',
-                  fontSize: '0.75em',
-                  backgroundColor: '#933',
-                  color: '#fff',
-                  border: '1px solid #a44',
-                  borderRadius: '3px',
-                  cursor: 'pointer'
-                }}
-              >
-                Unload
-              </button>
+              <div style={{ display: 'flex', gap: '6px' }}>
+                <button
+                  onClick={() => openInGoogleSheets(sheetId)}
+                  style={{
+                    padding: '0.3em 0.6em',
+                    fontSize: '0.75em',
+                    backgroundColor: '#333',
+                    color: '#8bc34a',
+                    border: '1px solid #555',
+                    borderRadius: '3px',
+                    cursor: 'pointer'
+                  }}
+                >
+                  GSheets
+                </button>
+                <button
+                  onClick={unloadSheet}
+                  style={{
+                    padding: '0.3em 0.6em',
+                    fontSize: '0.75em',
+                    backgroundColor: '#933',
+                    color: '#fff',
+                    border: '1px solid #a44',
+                    borderRadius: '3px',
+                    cursor: 'pointer'
+                  }}
+                >
+                  Unload
+                </button>
+              </div>
             </div>
             <div style={{
               display: 'flex',
@@ -367,34 +387,54 @@ export function App() {
                     {formatRelativeTime(data.lastOpened)}
                   </div>
                 </div>
-                <button
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    deleteSheetFromHistory(id);
-                  }}
-                  style={{
-                    padding: '0.3em 0.6em',
-                    fontSize: '0.75em',
-                    backgroundColor: '#333',
-                    color: '#999',
-                    border: '1px solid #444',
-                    borderRadius: '3px',
-                    cursor: 'pointer',
-                    whiteSpace: 'nowrap'
-                  }}
-                  onMouseEnter={(e) => {
-                    e.target.style.backgroundColor = '#933';
-                    e.target.style.color = '#fff';
-                    e.target.style.borderColor = '#a44';
-                  }}
-                  onMouseLeave={(e) => {
-                    e.target.style.backgroundColor = '#333';
-                    e.target.style.color = '#999';
-                    e.target.style.borderColor = '#444';
-                  }}
-                >
-                  Delete
-                </button>
+                <div style={{ display: 'flex', gap: '6px', alignItems: 'center' }}>
+                  <button
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      openInGoogleSheets(id);
+                    }}
+                    style={{
+                      padding: '0.3em 0.6em',
+                      fontSize: '0.75em',
+                      backgroundColor: '#333',
+                      color: '#8bc34a',
+                      border: '1px solid #555',
+                      borderRadius: '3px',
+                      cursor: 'pointer',
+                      whiteSpace: 'nowrap'
+                    }}
+                  >
+                    GSheets
+                  </button>
+                  <button
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      deleteSheetFromHistory(id);
+                    }}
+                    style={{
+                      padding: '0.3em 0.6em',
+                      fontSize: '0.75em',
+                      backgroundColor: '#333',
+                      color: '#999',
+                      border: '1px solid #444',
+                      borderRadius: '3px',
+                      cursor: 'pointer',
+                      whiteSpace: 'nowrap'
+                    }}
+                    onMouseEnter={(e) => {
+                      e.target.style.backgroundColor = '#933';
+                      e.target.style.color = '#fff';
+                      e.target.style.borderColor = '#a44';
+                    }}
+                    onMouseLeave={(e) => {
+                      e.target.style.backgroundColor = '#333';
+                      e.target.style.color = '#999';
+                      e.target.style.borderColor = '#444';
+                    }}
+                  >
+                    Delete
+                  </button>
+                </div>
               </div>
             ))}
           </div>

--- a/src/components/workoutLog.jsx
+++ b/src/components/workoutLog.jsx
@@ -7,6 +7,7 @@ const gapi = window.gapi;
 const WorkoutLog = ({ accessToken, sheetId, onSheetTitleLoaded, onAuthRequired }) => {
   const [workouts, setWorkouts] = useState([]);
   const [exerciseVideoMap, setExerciseVideoMap] = useState({});
+  const [exerciseDetailsMap, setExerciseDetailsMap] = useState({});
   const [expandedVideos, setExpandedVideos] = useState({});
   const [error, setError] = useState(null);
   const [loading, setLoading] = useState(false);
@@ -182,31 +183,43 @@ const WorkoutLog = ({ accessToken, sheetId, onSheetTitleLoaded, onAuthRequired }
           console.warn('Could not fetch sheet title:', err);
         }
 
-        // 5. Fetch Exercises tab to get video link mapping
+        // 5. Fetch Exercises tab to get video and extra metadata per exercise
         const exercisesResponse = await gapi.client.sheets.spreadsheets.values.get({
           spreadsheetId: sheetId,
-          range: 'Exercises!A:D',
+          range: 'Exercises!A:Z',
         });
 
         const exercisesData = exercisesResponse.result.values;
         const videoMap = {};
+        const detailsMap = {};
         if (exercisesData && exercisesData.length > 1) {
-          // Assuming row 0 is headers, find the Exercise and VideoLink columns
+          // Assuming row 0 is headers, find the relevant columns
           const exerciseHeaders = exercisesData[0];
           const exerciseNameIndex = exerciseHeaders.indexOf('Exercise');
           const videoLinkIndex = exerciseHeaders.indexOf('VideoLink');
+          const muscleGroupIndex = exerciseHeaders.indexOf('MuscleGroup');
+          const equimentIndex = exerciseHeaders.indexOf('Equiment');
+          const equipmentIndex = exerciseHeaders.indexOf('Equipment');
+          const resolvedEquipmentIndex = equipmentIndex !== -1 ? equipmentIndex : equimentIndex;
 
-          if (exerciseNameIndex !== -1 && videoLinkIndex !== -1) {
+          if (exerciseNameIndex !== -1) {
             exercisesData.slice(1).forEach(row => {
               const exerciseName = row[exerciseNameIndex];
-              const videoLink = row[videoLinkIndex];
+              const videoLink = videoLinkIndex !== -1 ? (row[videoLinkIndex] || '') : '';
+              const muscleGroup = muscleGroupIndex !== -1 ? (row[muscleGroupIndex] || '') : '';
+              const equipment = resolvedEquipmentIndex !== -1 ? (row[resolvedEquipmentIndex] || '') : '';
+
               if (exerciseName && videoLink) {
                 videoMap[exerciseName] = videoLink;
+              }
+              if (exerciseName) {
+                detailsMap[exerciseName] = { muscleGroup, equipment };
               }
             });
           }
         }
         setExerciseVideoMap(videoMap);
+        setExerciseDetailsMap(detailsMap);
 
         // 6. Fetch WorkoutLog data
         const workoutResponse = await gapi.client.sheets.spreadsheets.values.get({
@@ -507,6 +520,9 @@ const WorkoutLog = ({ accessToken, sheetId, onSheetTitleLoaded, onAuthRequired }
                         )}
                         {exercises.map((exercise, exerciseIndex) => {
                           const videoLink = exerciseVideoMap[exercise.Exercise];
+                          const details = exerciseDetailsMap[exercise.Exercise] || {};
+                          const muscleGroup = details.muscleGroup || '';
+                          const equipment = details.equipment || '';
                           const videoId = getYouTubeVideoId(videoLink);
                           const exerciseKey = `${sectionName}-${exerciseIndex}`;
                           const showVideo = expandedVideos[exerciseKey];
@@ -548,80 +564,89 @@ const WorkoutLog = ({ accessToken, sheetId, onSheetTitleLoaded, onAuthRequired }
                                         gap: '10px'
                                       }}>
                                         <div style={{ fontSize: '1.05em', fontWeight: 600, minWidth: 0, flex: 1 }}>
-                                          {videoLink ? (
-                                            <a
-                                              href={videoLink}
-                                              target="_blank"
-                                              rel="noopener noreferrer"
-                                              style={{ color: '#646cff', textDecoration: 'none' }}
-                                              onMouseEnter={(e) => e.target.style.textDecoration = 'underline'}
-                                              onMouseLeave={(e) => e.target.style.textDecoration = 'none'}
-                                            >
-                                              {value}
-                                            </a>
-                                          ) : (
-                                            <span>{value}</span>
+                                          <div>
+                                            {videoLink ? (
+                                              <a
+                                                href={videoLink}
+                                                target="_blank"
+                                                rel="noopener noreferrer"
+                                                style={{ color: '#646cff', textDecoration: 'none' }}
+                                                onMouseEnter={(e) => e.target.style.textDecoration = 'underline'}
+                                                onMouseLeave={(e) => e.target.style.textDecoration = 'none'}
+                                              >
+                                                {value}
+                                              </a>
+                                            ) : (
+                                              <span>{value}</span>
+                                            )}
+                                          </div>
+                                          {(muscleGroup || equipment) && (
+                                            <div style={{ marginTop: '2px', fontSize: '0.8em', color: '#999', fontWeight: 400 }}>
+                                              {muscleGroup}{muscleGroup && equipment ? ' • ' : ''}{equipment}
+                                            </div>
                                           )}
                                         </div>
-                                        <div style={{ display: 'flex', alignItems: 'center', gap: '6px', marginLeft: 'auto' }}>
-                                          {videoId && (
-                                            <button
-                                              onClick={() => toggleVideo(exerciseKey)}
-                                              title={showVideo ? 'Hide video' : 'Show video'}
-                                              aria-label={showVideo ? 'Hide video' : 'Show video'}
-                                              style={{
-                                                padding: '2px 8px',
-                                                fontSize: '0.85em',
-                                                backgroundColor: '#333',
-                                                color: '#aaa',
-                                                border: '1px solid #444',
-                                                borderRadius: '3px',
-                                                cursor: 'pointer'
-                                              }}
-                                            >
-                                              📹
-                                            </button>
-                                          )}
-                                          {canEditNotes ? (
-                                            <button
-                                              onClick={() => setEditingNotes(prev => ({
-                                                ...prev,
-                                                [exerciseKey]: notesValue
-                                              }))}
-                                              title={notesValue ? 'Edit notes' : 'Add notes'}
-                                              aria-label={notesValue ? 'Edit notes' : 'Add notes'}
-                                              style={{
-                                                padding: '2px 8px',
-                                                fontSize: '0.85em',
-                                                backgroundColor: '#333',
-                                                color: '#aaa',
-                                                border: '1px solid #444',
-                                                borderRadius: '3px',
-                                                cursor: 'pointer'
-                                              }}
-                                            >
-                                              📝
-                                            </button>
-                                          ) : (
-                                            <button
-                                              onClick={() => {
-                                                if (onAuthRequired) onAuthRequired();
-                                              }}
-                                              title={`Sign in to ${notesValue ? 'edit' : 'add'} notes`}
-                                              aria-label={`Sign in to ${notesValue ? 'edit' : 'add'} notes`}
-                                              style={{
-                                                padding: '2px 8px',
-                                                fontSize: '0.85em',
-                                                backgroundColor: '#646cff',
-                                                color: '#fff',
-                                                border: 'none',
-                                                borderRadius: '3px',
-                                                cursor: 'pointer'
-                                              }}
-                                            >
-                                              📝
-                                            </button>
-                                          )}
+                                        <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-end', gap: '2px', marginLeft: 'auto' }}>
+                                          <div style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
+                                            {videoId && (
+                                              <button
+                                                onClick={() => toggleVideo(exerciseKey)}
+                                                title={showVideo ? 'Hide video' : 'Show video'}
+                                                aria-label={showVideo ? 'Hide video' : 'Show video'}
+                                                style={{
+                                                  padding: '2px 8px',
+                                                  fontSize: '0.85em',
+                                                  backgroundColor: '#333',
+                                                  color: '#aaa',
+                                                  border: '1px solid #444',
+                                                  borderRadius: '3px',
+                                                  cursor: 'pointer'
+                                                }}
+                                              >
+                                                📹
+                                              </button>
+                                            )}
+                                            {canEditNotes ? (
+                                              <button
+                                                onClick={() => setEditingNotes(prev => ({
+                                                  ...prev,
+                                                  [exerciseKey]: notesValue
+                                                }))}
+                                                title={notesValue ? 'Edit notes' : 'Add notes'}
+                                                aria-label={notesValue ? 'Edit notes' : 'Add notes'}
+                                                style={{
+                                                  padding: '2px 8px',
+                                                  fontSize: '0.85em',
+                                                  backgroundColor: '#333',
+                                                  color: '#aaa',
+                                                  border: '1px solid #444',
+                                                  borderRadius: '3px',
+                                                  cursor: 'pointer'
+                                                }}
+                                              >
+                                                📝
+                                              </button>
+                                            ) : (
+                                              <button
+                                                onClick={() => {
+                                                  if (onAuthRequired) onAuthRequired();
+                                                }}
+                                                title={`Sign in to ${notesValue ? 'edit' : 'add'} notes`}
+                                                aria-label={`Sign in to ${notesValue ? 'edit' : 'add'} notes`}
+                                                style={{
+                                                  padding: '2px 8px',
+                                                  fontSize: '0.85em',
+                                                  backgroundColor: '#646cff',
+                                                  color: '#fff',
+                                                  border: 'none',
+                                                  borderRadius: '3px',
+                                                  cursor: 'pointer'
+                                                }}
+                                              >
+                                                📝
+                                              </button>
+                                            )}
+                                          </div>
                                         </div>
                                       </div>
                                       {showVideo && videoId && (


### PR DESCRIPTION
## Summary
- add `GSheets` quick-open buttons in sheet selector entries (including current sheet)
- enrich workout exercises with metadata from `Exercises` tab:
  - `MuscleGroup`
  - `Equiment` (also supports `Equipment` header)
- display metadata under exercise name while preserving existing workout layout/actions

## Validation
- npm run build