### PR TITLE
Restore last view on PWA reopen

### DIFF
--- a/src/app.jsx
+++ b/src/app.jsx
@@ -8,6 +8,8 @@ import './app.css';
 const gapi = window.gapi;
 
 const SHEETS_HISTORY_KEY = 'workout_sheets_history';
+const LAST_VIEW_KEY = 'workout_last_view';
+const getCurrentRoute = () => `${window.location.pathname}${window.location.search}`;
 
 export function App() {
   const [accessToken, setAccessToken] = useState(null);
@@ -16,7 +18,7 @@ export function App() {
   const [sheetId, setSheetId] = useState('');
   const [inputValue, setInputValue] = useState('');
   const [showSheetSelector, setShowSheetSelector] = useState(false);
-  const [currentPath, setCurrentPath] = useState(window.location.pathname);
+  const [currentPath, setCurrentPath] = useState(getCurrentRoute());
   const [showInstallBanner, setShowInstallBanner] = useState(false);
   const [isStandalonePwa, setIsStandalonePwa] = useState(false);
   const [shareMessage, setShareMessage] = useState('');
@@ -24,7 +26,7 @@ export function App() {
   // Simple router: listen to popstate and update current path
   useEffect(() => {
     const handlePopState = () => {
-      setCurrentPath(window.location.pathname);
+      setCurrentPath(getCurrentRoute());
     };
     window.addEventListener('popstate', handlePopState);
     return () => window.removeEventListener('popstate', handlePopState);
@@ -33,7 +35,7 @@ export function App() {
   // Navigate function
   const navigate = (path) => {
     window.history.pushState({}, '', path);
-    setCurrentPath(path);
+    setCurrentPath(getCurrentRoute());
   };
 
   // Detect if running as standalone PWA
@@ -45,6 +47,14 @@ export function App() {
     setIsStandalonePwa(Boolean(isStandalone));
 
     const hasBeenDismissed = localStorage.getItem('installBannerDismissed') === 'true';
+
+    if (isStandalone && window.location.pathname === '/') {
+      const lastView = localStorage.getItem(LAST_VIEW_KEY);
+      if (lastView && lastView !== '/') {
+        window.history.replaceState({}, '', lastView);
+        setCurrentPath(getCurrentRoute());
+      }
+    }
 
     if (!isStandalone && !hasBeenDismissed) {
       setShowInstallBanner(true);
@@ -200,14 +210,21 @@ export function App() {
   };
 
   useEffect(() => {
-    // Extract sheet ID from URL query parameter
+    // Persist last non-root route so standalone PWA can restore it on reopen.
+    if (window.location.pathname !== '/') {
+      localStorage.setItem(LAST_VIEW_KEY, getCurrentRoute());
+    }
+
+    // Keep selected sheet in sync with URL whenever route/query changes.
     const params = new URLSearchParams(window.location.search);
     const urlSheetId = params.get('sheet');
     if (urlSheetId) {
       setSheetId(urlSheetId);
       saveSheetToHistory(urlSheetId);
+    } else {
+      setSheetId('');
     }
-  }, []);
+  }, [currentPath]);
 
   useEffect(() => {
     // This effect handles the loading of the GAPI client library
@@ -546,7 +563,7 @@ export function App() {
   };
 
   // Show landing page for root path
-  if (currentPath === '/') {
+  if (new URL(currentPath, window.location.origin).pathname === '/') {
     return (
       <div class="app-container">
         <main>

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -23,13 +23,53 @@ export function App() {
   const [isStandalonePwa, setIsStandalonePwa] = useState(false);
   const [shareMessage, setShareMessage] = useState('');
 
-  // Simple router: listen to popstate and update current path
+  // Simple router: keep state in sync for popstate + pushState/replaceState.
   useEffect(() => {
-    const handlePopState = () => {
+    const syncCurrentPath = () => {
       setCurrentPath(getCurrentRoute());
     };
-    window.addEventListener('popstate', handlePopState);
-    return () => window.removeEventListener('popstate', handlePopState);
+
+    const originalPushState = window.history.pushState;
+    const originalReplaceState = window.history.replaceState;
+    const dispatchLocationChange = () => window.dispatchEvent(new Event('locationchange'));
+
+    window.history.pushState = function(...args) {
+      const result = originalPushState.apply(this, args);
+      dispatchLocationChange();
+      return result;
+    };
+
+    window.history.replaceState = function(...args) {
+      const result = originalReplaceState.apply(this, args);
+      dispatchLocationChange();
+      return result;
+    };
+
+    const persistLastView = () => {
+      if (window.location.pathname !== '/') {
+        localStorage.setItem(LAST_VIEW_KEY, getCurrentRoute());
+      }
+    };
+
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'hidden') {
+        persistLastView();
+      }
+    };
+
+    window.addEventListener('popstate', syncCurrentPath);
+    window.addEventListener('locationchange', syncCurrentPath);
+    window.addEventListener('pagehide', persistLastView);
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+
+    return () => {
+      window.history.pushState = originalPushState;
+      window.history.replaceState = originalReplaceState;
+      window.removeEventListener('popstate', syncCurrentPath);
+      window.removeEventListener('locationchange', syncCurrentPath);
+      window.removeEventListener('pagehide', persistLastView);
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+    };
   }, []);
 
   // Navigate function

--- a/src/components/workoutLog.jsx
+++ b/src/components/workoutLog.jsx
@@ -14,13 +14,27 @@ const WorkoutLog = ({ accessToken, sheetId, onSheetTitleLoaded, onAuthRequired, 
   const [editingSectionScores, setEditingSectionScores] = useState({}); // Track which section scores are being edited
   const [savingSectionScores, setSavingSectionScores] = useState({}); // Track which section scores are being saved
 
+  const parseLocalDateString = (value) => {
+    if (!value || !/^\d{4}-\d{2}-\d{2}$/.test(value)) return null;
+    const [year, month, day] = value.split('-').map(Number);
+    const parsedDate = new Date(year, month - 1, day);
+    return isNaN(parsedDate.getTime()) ? null : parsedDate;
+  };
+
+  const toDateKey = (date) => {
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, '0');
+    const day = String(date.getDate()).padStart(2, '0');
+    return `${year}-${month}-${day}`;
+  };
+
   // Initialize selected date from URL or default to today
   const getInitialDate = () => {
     const params = new URLSearchParams(window.location.search);
     const dateParam = params.get('date');
     if (dateParam) {
-      const parsedDate = new Date(dateParam);
-      if (!isNaN(parsedDate.getTime())) {
+      const parsedDate = parseLocalDateString(dateParam);
+      if (parsedDate) {
         return parsedDate;
       }
     }
@@ -41,7 +55,7 @@ const WorkoutLog = ({ accessToken, sheetId, onSheetTitleLoaded, onAuthRequired, 
 
   // Update URL when selected date changes
   useEffect(() => {
-    const dateStr = selectedDate.toISOString().split('T')[0];
+    const dateStr = toDateKey(selectedDate);
     const params = new URLSearchParams(window.location.search);
     params.set('date', dateStr);
     const newUrl = `${window.location.pathname}?${params.toString()}`;
@@ -312,13 +326,13 @@ const WorkoutLog = ({ accessToken, sheetId, onSheetTitleLoaded, onAuthRequired, 
   
   // Helper function to check if a date has workouts
   const hasWorkout = (date) => {
-    const dateStr = date.toISOString().split('T')[0];
+    const dateStr = toDateKey(date);
     return workouts.some(workout => workout.Date === dateStr);
   };
 
   // Helper function to get workouts for a specific date
   const getWorkoutsForDate = (date) => {
-    const dateStr = date.toISOString().split('T')[0];
+    const dateStr = toDateKey(date);
     return workouts.filter(workout => workout.Date === dateStr);
   };
 


### PR DESCRIPTION
## Summary
- persist the last non-root route (path + query) to localStorage
- on standalone PWA launch, restore that route instead of staying on `/`
- keep `sheetId` synchronized with URL query changes when route changes

## Why
Installed PWA sessions were always starting at the welcome page, which interrupted workout continuity.
