### PR TITLE
Fix load sheet button requiring two clicks

### DIFF
--- a/src/app.jsx
+++ b/src/app.jsx
@@ -563,7 +563,7 @@ export function App() {
             <input
               type="text"
               value={inputValue}
-              onChange={(e) => setInputValue(e.target.value)}
+              onInput={(e) => setInputValue(e.target.value)}
               placeholder="Sheet URL or ID"
               style={{
                 width: '100%',


### PR DESCRIPTION
## Summary
- switch the sheet URL/ID input to use Preact onInput
- ensure the latest typed value is available on the first submit click

## Why
In Preact, text input onChange fires on blur, so clicking the submit button could submit before state had the latest value, making the first click appear to do nothing.