### PR TITLE
Preserve last account hint for expired-session re-login

### DIFF
--- a/src/app.jsx
+++ b/src/app.jsx
@@ -14,6 +14,7 @@ const getCurrentRoute = () => `${window.location.pathname}${window.location.sear
 export function App() {
   const [accessToken, setAccessToken] = useState(null);
   const [forceLogoutVersion, setForceLogoutVersion] = useState(0);
+  const [authUiMessage, setAuthUiMessage] = useState('');
   const [isGapiLoaded, setIsGapiLoaded] = useState(false);
   const [sheetId, setSheetId] = useState('');
   const [inputValue, setInputValue] = useState('');
@@ -281,6 +282,9 @@ export function App() {
 
   const handleAuthChange = (token) => {
     setAccessToken(token);
+    if (token) {
+      setAuthUiMessage('');
+    }
   };
 
   const openPicker = () => {
@@ -670,7 +674,7 @@ export function App() {
               Sheet
             </button>
           )}
-          <Auth onAuthChange={handleAuthChange} forceLogoutVersion={forceLogoutVersion} />
+          <Auth accessToken={accessToken} onAuthChange={handleAuthChange} forceLogoutVersion={forceLogoutVersion} />
         </div>
       </header>
       <main>
@@ -686,6 +690,20 @@ export function App() {
             textAlign: 'center'
           }}>
             {shareMessage}
+          </div>
+        )}
+
+        {authUiMessage && (
+          <div style={{
+            backgroundColor: '#2a1a1a',
+            border: '1px solid #a44',
+            borderRadius: '4px',
+            padding: '0.75em',
+            marginBottom: '1em',
+            fontSize: '0.9em',
+            color: '#ffb3b3'
+          }}>
+            {authUiMessage}
           </div>
         )}
 
@@ -828,6 +846,7 @@ export function App() {
             sheetId={sheetId}
             onSheetTitleLoaded={updateSheetTitle}
             onSessionExpired={() => {
+              setAuthUiMessage('Login expired. Login again');
               setAccessToken(null);
               setForceLogoutVersion(v => v + 1);
             }}

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -703,7 +703,10 @@ export function App() {
             fontSize: '0.9em',
             color: '#ffb3b3'
           }}>
-            {authUiMessage}
+            <div>{authUiMessage}</div>
+            <div style={{ marginTop: '0.35em', fontSize: '0.8em', color: '#aaa' }}>
+              stored email hint: {localStorage.getItem('google_user_email') || 'none'}
+            </div>
           </div>
         )}
 

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -703,10 +703,7 @@ export function App() {
             fontSize: '0.9em',
             color: '#ffb3b3'
           }}>
-            <div>{authUiMessage}</div>
-            <div style={{ marginTop: '0.35em', fontSize: '0.8em', color: '#aaa' }}>
-              stored email hint: {localStorage.getItem('google_user_email') || 'none'}
-            </div>
+            {authUiMessage}
           </div>
         )}
 

--- a/src/components/auth.jsx
+++ b/src/components/auth.jsx
@@ -2,33 +2,33 @@ import { useState, useEffect } from 'preact/hooks';
 
 const STORAGE_KEY = 'google_access_token';
 const USER_NAME_KEY = 'google_user_name';
+const USER_EMAIL_KEY = 'google_user_email';
 
-const Auth = ({ onAuthChange, forceLogoutVersion = 0 }) => {
+const Auth = ({ accessToken, onAuthChange, forceLogoutVersion = 0 }) => {
   const [tokenClient, setTokenClient] = useState(null);
-  const [accessToken, setAccessToken] = useState(null);
   const [userName, setUserName] = useState(null);
 
-  const clearAuthState = () => {
-    setAccessToken(null);
+  const clearAuthState = ({ clearStoredEmail = false } = {}) => {
     setUserName(null);
     localStorage.removeItem(STORAGE_KEY);
     localStorage.removeItem(USER_NAME_KEY);
+    if (clearStoredEmail) {
+      localStorage.removeItem(USER_EMAIL_KEY);
+    }
     onAuthChange(null);
   };
 
-  // Restore token and user name from localStorage on mount
   useEffect(() => {
     const storedToken = localStorage.getItem(STORAGE_KEY);
     const storedUserName = localStorage.getItem(USER_NAME_KEY);
     if (storedToken) {
       console.log('Restored token from localStorage');
-      setAccessToken(storedToken);
       onAuthChange(storedToken);
       if (storedUserName) {
         setUserName(storedUserName);
       }
     }
-  }, [onAuthChange]);
+  }, []);
 
   useEffect(() => {
     const initializeGis = () => {
@@ -37,15 +37,13 @@ const Auth = ({ onAuthChange, forceLogoutVersion = 0 }) => {
         console.log('Client ID:', import.meta.env.VITE_GOOGLE_CLIENT_ID);
         const client = window.google.accounts.oauth2.initTokenClient({
           client_id: import.meta.env.VITE_GOOGLE_CLIENT_ID,
-          scope: 'https://www.googleapis.com/auth/spreadsheets https://www.googleapis.com/auth/drive.file https://www.googleapis.com/auth/userinfo.profile',
+          scope: 'https://www.googleapis.com/auth/spreadsheets https://www.googleapis.com/auth/drive.file https://www.googleapis.com/auth/userinfo.profile https://www.googleapis.com/auth/userinfo.email',
           callback: async (tokenResponse) => {
             console.log('Token response received:', tokenResponse);
             if (tokenResponse && tokenResponse.access_token) {
-              setAccessToken(tokenResponse.access_token);
               localStorage.setItem(STORAGE_KEY, tokenResponse.access_token);
               onAuthChange(tokenResponse.access_token);
 
-              // Fetch user info to get the name
               try {
                 const userInfoResponse = await fetch('https://www.googleapis.com/oauth2/v2/userinfo', {
                   headers: {
@@ -56,6 +54,9 @@ const Auth = ({ onAuthChange, forceLogoutVersion = 0 }) => {
                 if (userInfo.name) {
                   setUserName(userInfo.name);
                   localStorage.setItem(USER_NAME_KEY, userInfo.name);
+                }
+                if (userInfo.email) {
+                  localStorage.setItem(USER_EMAIL_KEY, userInfo.email);
                 }
               } catch (err) {
                 console.error('Error fetching user info:', err);
@@ -68,8 +69,6 @@ const Auth = ({ onAuthChange, forceLogoutVersion = 0 }) => {
       }
     };
 
-    // The GIS script is loaded asynchronously. We need to wait for it.
-    // A simple timeout is used here, but a more robust solution could be implemented.
     const checkGisReady = setInterval(() => {
       if (window.google && window.google.accounts) {
         clearInterval(checkGisReady);
@@ -84,10 +83,9 @@ const Auth = ({ onAuthChange, forceLogoutVersion = 0 }) => {
     console.log('Login button clicked');
     console.log('Token client available:', !!tokenClient);
     if (tokenClient) {
-      // Prompt the user to select a Google Account and ask for consent to share their data
-      // when establishing a new session.
-      console.log('Requesting access token...');
-      tokenClient.requestAccessToken();
+      const loginHint = localStorage.getItem(USER_EMAIL_KEY);
+      console.log('Requesting access token...', loginHint ? 'with login hint' : 'without login hint');
+      tokenClient.requestAccessToken(loginHint ? { hint: loginHint } : {});
     } else {
       console.error('Token client not initialized');
     }
@@ -95,19 +93,17 @@ const Auth = ({ onAuthChange, forceLogoutVersion = 0 }) => {
 
   const handleLogout = () => {
     const tokenToRevoke = accessToken;
-    clearAuthState();
+    clearAuthState({ clearStoredEmail: true });
 
     if (tokenToRevoke && window.google?.accounts?.oauth2?.revoke) {
-      // Revoke in background; do not block local logout on callback.
       window.google.accounts.oauth2.revoke(tokenToRevoke, () => {});
     }
   };
 
-  // Force logout when session is detected as expired by API calls.
   useEffect(() => {
     if (forceLogoutVersion === 0) return;
 
-    clearAuthState();
+    clearAuthState({ clearStoredEmail: false });
   }, [forceLogoutVersion]);
 
   return (

--- a/src/components/auth.jsx
+++ b/src/components/auth.jsx
@@ -84,8 +84,8 @@ const Auth = ({ accessToken, onAuthChange, forceLogoutVersion = 0 }) => {
     console.log('Token client available:', !!tokenClient);
     if (tokenClient) {
       const loginHint = localStorage.getItem(USER_EMAIL_KEY);
-      console.log('Requesting access token...', loginHint ? 'with login hint' : 'without login hint');
-      tokenClient.requestAccessToken(loginHint ? { hint: loginHint } : {});
+      console.log('Requesting access token...', loginHint ? 'with login_hint' : 'without login_hint');
+      tokenClient.requestAccessToken(loginHint ? { login_hint: loginHint } : {});
     } else {
       console.error('Token client not initialized');
     }

--- a/src/components/auth.jsx
+++ b/src/components/auth.jsx
@@ -84,8 +84,8 @@ const Auth = ({ accessToken, onAuthChange, forceLogoutVersion = 0 }) => {
     console.log('Token client available:', !!tokenClient);
     if (tokenClient) {
       const loginHint = localStorage.getItem(USER_EMAIL_KEY);
-      console.log('Requesting access token...', loginHint ? 'with login_hint' : 'without login_hint');
-      tokenClient.requestAccessToken(loginHint ? { login_hint: loginHint } : {});
+      console.log('Requesting access token...', loginHint ? 'with login_hint and prompt=""' : 'with prompt="" and without login_hint');
+      tokenClient.requestAccessToken(loginHint ? { login_hint: loginHint, prompt: '' } : { prompt: '' });
     } else {
       console.error('Token client not initialized');
     }

--- a/src/components/workoutLog.jsx
+++ b/src/components/workoutLog.jsx
@@ -552,26 +552,28 @@ const WorkoutLog = ({ accessToken, sheetId, onSheetTitleLoaded, onAuthRequired, 
   }
 
   if (error) {
-    // Don't show the "open it in Sheets" link for authentication errors
+    // Don't show the local auth-expired block, the app/header handles that state.
     const isAuthError = error === 'Login expired. Login again';
+
+    if (isAuthError) {
+      return null;
+    }
 
     return (
       <div style={{ color: 'red' }}>
         <p>{error}</p>
-        {!isAuthError && (
-          <p style={{ marginTop: '1em', fontSize: '0.9em' }}>
-            Can you{' '}
-            <a
-              href={`https://docs.google.com/spreadsheets/d/${sheetId}`}
-              target="_blank"
-              rel="noopener noreferrer"
-              style={{ color: '#646cff', textDecoration: 'underline' }}
-            >
-              open it in Sheets
-            </a>
-            ? If you can access it there, the sharing permissions may need to be adjusted.
-          </p>
-        )}
+        <p style={{ marginTop: '1em', fontSize: '0.9em' }}>
+          Can you{' '}
+          <a
+            href={`https://docs.google.com/spreadsheets/d/${sheetId}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            style={{ color: '#646cff', textDecoration: 'underline' }}
+          >
+            open it in Sheets
+          </a>
+          ? If you can access it there, the sharing permissions may need to be adjusted.
+        </p>
       </div>
     );
   }


### PR DESCRIPTION
## Summary
- preserve the last used Google email across session expiry so re-login can hint the same account
- when the session expires, clear the access token and switch the header from Log Out to Log In
- keep the user email only for expiry recovery, but clear it on explicit logout
- let the user-triggered Log In action request a token with the stored email hint when available

## Validation
- npm run build

## Related
- Improves expired-session re-auth UX
- Related to #53
