### PR TITLE
Add drag navigation to workout week strip

### DIFF
--- a/src/components/workoutLog.jsx
+++ b/src/components/workoutLog.jsx
@@ -202,12 +202,18 @@ const WorkoutLog = ({ accessToken, sheetId, onSheetTitleLoaded, onAuthRequired, 
     });
   };
 
-  const animateWeekShift = (days, direction) => {
+  const animateWeekShift = (days, direction, currentOffset = 0) => {
     const offscreenOffset = direction === 'next' ? -220 : 220;
     const incomingOffset = direction === 'next' ? 220 : -220;
 
     setWeekSlideTransition('transform 0.22s ease-out');
-    setWeekDragOffset(offscreenOffset);
+    setWeekDragOffset(currentOffset);
+
+    window.requestAnimationFrame(() => {
+      window.requestAnimationFrame(() => {
+        setWeekDragOffset(offscreenOffset);
+      });
+    });
 
     window.setTimeout(() => {
       shiftSelectedDateByDays(days);
@@ -253,7 +259,7 @@ const WorkoutLog = ({ accessToken, sheetId, onSheetTitleLoaded, onAuthRequired, 
 
     if (Math.abs(deltaX) >= 70) {
       state.navigated = true;
-      animateWeekShift(deltaX > 0 ? -7 : 7, deltaX > 0 ? 'prev' : 'next');
+      animateWeekShift(deltaX > 0 ? -7 : 7, deltaX > 0 ? 'prev' : 'next', Math.max(-120, Math.min(120, deltaX * 0.65)));
     }
   };
 

--- a/src/components/workoutLog.jsx
+++ b/src/components/workoutLog.jsx
@@ -120,6 +120,7 @@ const WorkoutLog = ({ accessToken, sheetId, onSheetTitleLoaded, onAuthRequired, 
   const [viewMode, setViewMode] = useState('week'); // 'week' or 'month'
   const [currentMonth, setCurrentMonth] = useState(new Date());
   const [weekDragOffset, setWeekDragOffset] = useState(0);
+  const [weekSlideTransition, setWeekSlideTransition] = useState('transform 0.18s ease-out');
   const weekDragStateRef = useRef({
     pointerId: null,
     startX: 0,
@@ -201,6 +202,27 @@ const WorkoutLog = ({ accessToken, sheetId, onSheetTitleLoaded, onAuthRequired, 
     });
   };
 
+  const animateWeekShift = (days, direction) => {
+    const offscreenOffset = direction === 'next' ? -220 : 220;
+    const incomingOffset = direction === 'next' ? 220 : -220;
+
+    setWeekSlideTransition('transform 0.22s ease-out');
+    setWeekDragOffset(offscreenOffset);
+
+    window.setTimeout(() => {
+      shiftSelectedDateByDays(days);
+      setWeekSlideTransition('none');
+      setWeekDragOffset(incomingOffset);
+
+      window.requestAnimationFrame(() => {
+        window.requestAnimationFrame(() => {
+          setWeekSlideTransition('transform 0.22s ease-out');
+          setWeekDragOffset(0);
+        });
+      });
+    }, 220);
+  };
+
   const handleWeekPointerDown = (event) => {
     if (viewMode !== 'week') return;
     weekDragStateRef.current = {
@@ -224,20 +246,21 @@ const WorkoutLog = ({ accessToken, sheetId, onSheetTitleLoaded, onAuthRequired, 
         return;
       }
       state.dragging = true;
+      setWeekSlideTransition('none');
     }
 
-    setWeekDragOffset(Math.max(-72, Math.min(72, deltaX * 0.35)));
+    setWeekDragOffset(Math.max(-120, Math.min(120, deltaX * 0.65)));
 
-    if (Math.abs(deltaX) >= 50) {
-      shiftSelectedDateByDays(deltaX > 0 ? -7 : 7);
+    if (Math.abs(deltaX) >= 70) {
       state.navigated = true;
-      setWeekDragOffset(0);
+      animateWeekShift(deltaX > 0 ? -7 : 7, deltaX > 0 ? 'prev' : 'next');
     }
   };
 
   const resetWeekPointerState = (event) => {
     const state = weekDragStateRef.current;
     if (event && state.pointerId !== event.pointerId) return;
+    setWeekSlideTransition('transform 0.18s ease-out');
     setWeekDragOffset(0);
     weekDragStateRef.current = {
       pointerId: null,
@@ -799,7 +822,8 @@ const WorkoutLog = ({ accessToken, sheetId, onSheetTitleLoaded, onAuthRequired, 
               touchAction: 'pan-y',
               userSelect: 'none',
               transform: `translateX(${weekDragOffset}px)`,
-              transition: weekDragStateRef.current.dragging ? 'none' : 'transform 0.18s ease-out'
+              transition: weekSlideTransition,
+              willChange: 'transform'
             }}
           >
             {weekDates.map((date, index) => {

--- a/src/components/workoutLog.jsx
+++ b/src/components/workoutLog.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'preact/hooks';
+import { useState, useEffect, useRef } from 'preact/hooks';
 import { validateSpreadsheetSchema, formatValidationErrors } from '../utils/schemaValidator';
 
 // We access gapi via the window object, as it's loaded from a script tag.
@@ -119,6 +119,13 @@ const WorkoutLog = ({ accessToken, sheetId, onSheetTitleLoaded, onAuthRequired, 
   const [weekDates, setWeekDates] = useState([]);
   const [viewMode, setViewMode] = useState('week'); // 'week' or 'month'
   const [currentMonth, setCurrentMonth] = useState(new Date());
+  const weekDragStateRef = useRef({
+    pointerId: null,
+    startX: 0,
+    startY: 0,
+    dragging: false,
+    navigated: false,
+  });
 
   const toggleVideo = (exerciseKey) => {
     setExpandedVideos(prev => ({
@@ -183,6 +190,57 @@ const WorkoutLog = ({ accessToken, sheetId, onSheetTitleLoaded, onAuthRequired, 
     const newMonth = new Date(currentMonth);
     newMonth.setMonth(currentMonth.getMonth() + offset);
     setCurrentMonth(newMonth);
+  };
+
+  const shiftSelectedDateByDays = (days) => {
+    setSelectedDate(prev => {
+      const next = new Date(prev);
+      next.setDate(prev.getDate() + days);
+      return next;
+    });
+  };
+
+  const handleWeekPointerDown = (event) => {
+    if (viewMode !== 'week') return;
+    weekDragStateRef.current = {
+      pointerId: event.pointerId,
+      startX: event.clientX,
+      startY: event.clientY,
+      dragging: false,
+      navigated: false,
+    };
+  };
+
+  const handleWeekPointerMove = (event) => {
+    const state = weekDragStateRef.current;
+    if (state.pointerId !== event.pointerId || state.navigated) return;
+
+    const deltaX = event.clientX - state.startX;
+    const deltaY = event.clientY - state.startY;
+
+    if (!state.dragging) {
+      if (Math.abs(deltaX) < 18 || Math.abs(deltaX) <= Math.abs(deltaY)) {
+        return;
+      }
+      state.dragging = true;
+    }
+
+    if (Math.abs(deltaX) >= 50) {
+      shiftSelectedDateByDays(deltaX > 0 ? -7 : 7);
+      state.navigated = true;
+    }
+  };
+
+  const resetWeekPointerState = (event) => {
+    const state = weekDragStateRef.current;
+    if (event && state.pointerId !== event.pointerId) return;
+    weekDragStateRef.current = {
+      pointerId: null,
+      startX: 0,
+      startY: 0,
+      dragging: false,
+      navigated: false,
+    };
   };
 
   // Helper function to extract YouTube video ID from URL
@@ -719,13 +777,21 @@ const WorkoutLog = ({ accessToken, sheetId, onSheetTitleLoaded, onAuthRequired, 
       {viewMode === 'week' ? (
         // Week View
         <div>
-          <div style={{
-            display: 'grid',
-            gridTemplateColumns: 'repeat(7, 1fr)',
-            gap: '5px',
-            marginBottom: '20px',
-            width: '100%'
-          }}>
+          <div
+            onPointerDown={handleWeekPointerDown}
+            onPointerMove={handleWeekPointerMove}
+            onPointerUp={resetWeekPointerState}
+            onPointerCancel={resetWeekPointerState}
+            style={{
+              display: 'grid',
+              gridTemplateColumns: 'repeat(7, 1fr)',
+              gap: '5px',
+              marginBottom: '20px',
+              width: '100%',
+              touchAction: 'pan-y',
+              userSelect: 'none'
+            }}
+          >
             {weekDates.map((date, index) => {
               const hasWorkoutOnDate = hasWorkout(date);
               const isSelected = isSelectedDate(date);
@@ -734,7 +800,12 @@ const WorkoutLog = ({ accessToken, sheetId, onSheetTitleLoaded, onAuthRequired, 
               return (
                 <div
                   key={index}
-                  onClick={() => setSelectedDate(date)}
+                  onClick={() => {
+                    if (weekDragStateRef.current.dragging || weekDragStateRef.current.navigated) {
+                      return;
+                    }
+                    setSelectedDate(date);
+                  }}
                   style={{
                     padding: '10px 5px',
                     textAlign: 'center',

--- a/src/components/workoutLog.jsx
+++ b/src/components/workoutLog.jsx
@@ -119,6 +119,7 @@ const WorkoutLog = ({ accessToken, sheetId, onSheetTitleLoaded, onAuthRequired, 
   const [weekDates, setWeekDates] = useState([]);
   const [viewMode, setViewMode] = useState('week'); // 'week' or 'month'
   const [currentMonth, setCurrentMonth] = useState(new Date());
+  const [weekDragOffset, setWeekDragOffset] = useState(0);
   const weekDragStateRef = useRef({
     pointerId: null,
     startX: 0,
@@ -225,15 +226,19 @@ const WorkoutLog = ({ accessToken, sheetId, onSheetTitleLoaded, onAuthRequired, 
       state.dragging = true;
     }
 
+    setWeekDragOffset(Math.max(-72, Math.min(72, deltaX * 0.35)));
+
     if (Math.abs(deltaX) >= 50) {
       shiftSelectedDateByDays(deltaX > 0 ? -7 : 7);
       state.navigated = true;
+      setWeekDragOffset(0);
     }
   };
 
   const resetWeekPointerState = (event) => {
     const state = weekDragStateRef.current;
     if (event && state.pointerId !== event.pointerId) return;
+    setWeekDragOffset(0);
     weekDragStateRef.current = {
       pointerId: null,
       startX: 0,
@@ -777,6 +782,9 @@ const WorkoutLog = ({ accessToken, sheetId, onSheetTitleLoaded, onAuthRequired, 
       {viewMode === 'week' ? (
         // Week View
         <div>
+          <div style={{ marginBottom: '8px', fontSize: '0.8em', color: '#888', textAlign: 'center' }}>
+            Drag left or right to switch weeks
+          </div>
           <div
             onPointerDown={handleWeekPointerDown}
             onPointerMove={handleWeekPointerMove}
@@ -789,7 +797,9 @@ const WorkoutLog = ({ accessToken, sheetId, onSheetTitleLoaded, onAuthRequired, 
               marginBottom: '20px',
               width: '100%',
               touchAction: 'pan-y',
-              userSelect: 'none'
+              userSelect: 'none',
+              transform: `translateX(${weekDragOffset}px)`,
+              transition: weekDragStateRef.current.dragging ? 'none' : 'transform 0.18s ease-out'
             }}
           >
             {weekDates.map((date, index) => {


### PR DESCRIPTION
## Summary
- add horizontal drag/swipe navigation to the week strip in workout week view
- keep normal tap selection for individual days
- preserve vertical page scrolling while swiping horizontally between weeks

## Validation
- npm run build
