### PR TITLE
Add focused section timer view

### DIFF
--- a/src/components/workoutLog.jsx
+++ b/src/components/workoutLog.jsx
@@ -863,7 +863,8 @@ const WorkoutLog = ({ accessToken, sheetId, onSheetTitleLoaded, onAuthRequired, 
                 color: sectionStopwatchRunning ? '#111' : '#fff'
               }}
             >
-              <div style={{ display: 'flex', justifyContent: 'flex-end', marginBottom: '4px' }}>
+              <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: '10px' }}>
+                <div style={{ fontSize: '2.1em', fontWeight: 700 }}>{formatStopwatchTime(sectionStopwatchSeconds)}</div>
                 <span
                   onClick={(event) => {
                     event.stopPropagation();
@@ -882,13 +883,13 @@ const WorkoutLog = ({ accessToken, sheetId, onSheetTitleLoaded, onAuthRequired, 
                     borderRadius: '999px',
                     border: `1px solid ${sectionStopwatchRunning ? '#86b85f' : '#444'}`,
                     color: sectionStopwatchRunning ? '#335214' : '#bbb',
-                    fontSize: '0.95em'
+                    fontSize: '0.95em',
+                    flexShrink: 0
                   }}
                 >
                   ↺
                 </span>
               </div>
-              <div style={{ fontSize: '2.1em', fontWeight: 700 }}>{formatStopwatchTime(sectionStopwatchSeconds)}</div>
             </div>
             <button
               onClick={() => setSectionRoundCount(prev => prev + 1)}
@@ -902,7 +903,8 @@ const WorkoutLog = ({ accessToken, sheetId, onSheetTitleLoaded, onAuthRequired, 
                 cursor: 'pointer'
               }}
             >
-              <div style={{ display: 'flex', justifyContent: 'flex-end', marginBottom: '4px' }}>
+              <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: '10px' }}>
+                <div style={{ fontSize: '2.8em', fontWeight: 700 }}>{sectionRoundCount}</div>
                 <span
                   onClick={(event) => {
                     event.stopPropagation();
@@ -920,13 +922,13 @@ const WorkoutLog = ({ accessToken, sheetId, onSheetTitleLoaded, onAuthRequired, 
                     borderRadius: '999px',
                     border: '1px solid #3f5ea8',
                     color: '#c9d5ff',
-                    fontSize: '0.95em'
+                    fontSize: '0.95em',
+                    flexShrink: 0
                   }}
                 >
                   ↺
                 </span>
               </div>
-              <div style={{ fontSize: '2.8em', fontWeight: 700 }}>{sectionRoundCount}</div>
             </button>
           </div>
 

--- a/src/components/workoutLog.jsx
+++ b/src/components/workoutLog.jsx
@@ -848,7 +848,7 @@ const WorkoutLog = ({ accessToken, sheetId, onSheetTitleLoaded, onAuthRequired, 
 
           <div style={{
             display: 'grid',
-            gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))',
+            gridTemplateColumns: 'repeat(2, minmax(0, 1fr))',
             gap: '12px',
             marginBottom: '20px'
           }}>

--- a/src/components/workoutLog.jsx
+++ b/src/components/workoutLog.jsx
@@ -133,6 +133,7 @@ const WorkoutLog = ({ accessToken, sheetId, onSheetTitleLoaded, onAuthRequired, 
   const [sectionStopwatchSeconds, setSectionStopwatchSeconds] = useState(0);
   const [sectionStopwatchRunning, setSectionStopwatchRunning] = useState(false);
   const [sectionRoundCount, setSectionRoundCount] = useState(0);
+  const focusedSectionHasPendingChangesRef = useRef(false);
   const weekDragStateRef = useRef({
     pointerId: null,
     startX: 0,
@@ -215,6 +216,7 @@ const WorkoutLog = ({ accessToken, sheetId, onSheetTitleLoaded, onAuthRequired, 
     const parsedStats = getSectionAutoStats(lastExercise?.['Section Score'] || '');
     const stopwatchSeconds = parseStopwatchTimeToSeconds(parsedStats.timer);
 
+    focusedSectionHasPendingChangesRef.current = false;
     setFocusedSectionName(sectionName);
     setFocusedSectionPrescription(sectionPrescription || '');
     setFocusedSectionExercises(exercises);
@@ -224,6 +226,7 @@ const WorkoutLog = ({ accessToken, sheetId, onSheetTitleLoaded, onAuthRequired, 
   };
 
   const closeFocusedSection = () => {
+    focusedSectionHasPendingChangesRef.current = false;
     setFocusedSectionName(null);
     setFocusedSectionPrescription('');
     setFocusedSectionExercises([]);
@@ -821,6 +824,11 @@ const WorkoutLog = ({ accessToken, sheetId, onSheetTitleLoaded, onAuthRequired, 
 
   const updateFocusedSectionStats = async () => {
     if (!focusedSectionName || focusedSectionExercises.length === 0) return;
+    if (!focusedSectionHasPendingChangesRef.current) return;
+    if (!accessToken) {
+      if (onAuthRequired) onAuthRequired();
+      return;
+    }
 
     const timerText = formatStopwatchTime(sectionStopwatchSeconds);
     const lastFocusedExercise = focusedSectionExercises[focusedSectionExercises.length - 1];
@@ -830,6 +838,10 @@ const WorkoutLog = ({ accessToken, sheetId, onSheetTitleLoaded, onAuthRequired, 
     const nextSectionScore = buildSectionScoreValue(parsedStats.manualText, timerText, sectionRoundCount);
 
     if (!lastFocusedRowNumber) return;
+    if (nextSectionScore === (currentWorkoutSection?.['Section Score'] || lastFocusedExercise?.['Section Score'] || '')) {
+      focusedSectionHasPendingChangesRef.current = false;
+      return;
+    }
 
     try {
       await ensureSheetsApiReady();
@@ -874,6 +886,7 @@ const WorkoutLog = ({ accessToken, sheetId, onSheetTitleLoaded, onAuthRequired, 
           ? { ...exercise, ['Section Score']: nextSectionScore }
           : exercise
       ));
+      focusedSectionHasPendingChangesRef.current = false;
     } catch (err) {
       console.error('Error saving focused section stats:', err);
       alert(`Error saving focused section stats: ${err.result?.error?.message || err.message}`);
@@ -921,7 +934,10 @@ const WorkoutLog = ({ accessToken, sheetId, onSheetTitleLoaded, onAuthRequired, 
             marginBottom: '20px'
           }}>
             <div
-              onClick={() => setSectionStopwatchRunning(prev => !prev)}
+              onClick={() => {
+                focusedSectionHasPendingChangesRef.current = true;
+                setSectionStopwatchRunning(prev => !prev);
+              }}
               style={{
                 backgroundColor: sectionStopwatchRunning ? '#b9e97c' : '#1a1a1a',
                 border: `1px solid ${sectionStopwatchRunning ? '#b9e97c' : '#333'}`,
@@ -936,6 +952,7 @@ const WorkoutLog = ({ accessToken, sheetId, onSheetTitleLoaded, onAuthRequired, 
                 <span
                   onClick={(event) => {
                     event.stopPropagation();
+                    focusedSectionHasPendingChangesRef.current = true;
                     setSectionStopwatchRunning(false);
                     setSectionStopwatchSeconds(0);
                   }}
@@ -960,7 +977,10 @@ const WorkoutLog = ({ accessToken, sheetId, onSheetTitleLoaded, onAuthRequired, 
               </div>
             </div>
             <button
-              onClick={() => setSectionRoundCount(prev => prev + 1)}
+              onClick={() => {
+                focusedSectionHasPendingChangesRef.current = true;
+                setSectionRoundCount(prev => prev + 1);
+              }}
               style={{
                 backgroundColor: '#1d2a44',
                 border: '1px solid #3f5ea8',
@@ -976,6 +996,7 @@ const WorkoutLog = ({ accessToken, sheetId, onSheetTitleLoaded, onAuthRequired, 
                 <span
                   onClick={(event) => {
                     event.stopPropagation();
+                    focusedSectionHasPendingChangesRef.current = true;
                     setSectionRoundCount(0);
                   }}
                   role="button"

--- a/src/components/workoutLog.jsx
+++ b/src/components/workoutLog.jsx
@@ -3,7 +3,6 @@ import { validateSpreadsheetSchema, formatValidationErrors } from '../utils/sche
 
 // We access gapi via the window object, as it's loaded from a script tag.
 const gapi = window.gapi;
-const SECTION_FOCUS_STATS_KEY = 'workout_section_focus_stats';
 
 const WorkoutLog = ({ accessToken, sheetId, onSheetTitleLoaded, onAuthRequired, onSessionExpired }) => {
   const [workouts, setWorkouts] = useState([]);
@@ -128,7 +127,6 @@ const WorkoutLog = ({ accessToken, sheetId, onSheetTitleLoaded, onAuthRequired, 
   const [sectionStopwatchSeconds, setSectionStopwatchSeconds] = useState(0);
   const [sectionStopwatchRunning, setSectionStopwatchRunning] = useState(false);
   const [sectionRoundCount, setSectionRoundCount] = useState(0);
-  const [sectionFocusStats, setSectionFocusStats] = useState({});
   const weekDragStateRef = useRef({
     pointerId: null,
     startX: 0,
@@ -147,26 +145,24 @@ const WorkoutLog = ({ accessToken, sheetId, onSheetTitleLoaded, onAuthRequired, 
     return () => window.clearInterval(intervalId);
   }, [sectionStopwatchRunning]);
 
-  const getSectionFocusStatsKey = (date, sectionName) => `${toDateKey(date)}::${sectionName}`;
-
-  useEffect(() => {
-    try {
-      const raw = localStorage.getItem(SECTION_FOCUS_STATS_KEY);
-      if (raw) {
-        setSectionFocusStats(JSON.parse(raw));
-      }
-    } catch (err) {
-      console.error('Error loading section focus stats:', err);
+  const getSectionAutoStats = (sectionScoreValue = '') => {
+    const match = sectionScoreValue.match(/\[auto:\s*(\d{2}:\d{2}(?::\d{2})?)\s*\/\s*(\d+)\]$/);
+    if (!match) {
+      return { timer: '', rounds: 0, manualText: sectionScoreValue.trim() };
     }
-  }, []);
 
-  useEffect(() => {
-    try {
-      localStorage.setItem(SECTION_FOCUS_STATS_KEY, JSON.stringify(sectionFocusStats));
-    } catch (err) {
-      console.error('Error saving section focus stats:', err);
-    }
-  }, [sectionFocusStats]);
+    return {
+      timer: match[1],
+      rounds: Number(match[2]) || 0,
+      manualText: sectionScoreValue.replace(match[0], '').trim(),
+    };
+  };
+
+  const buildSectionScoreValue = (manualText = '', timer = '', rounds = 0) => {
+    const autoPart = timer ? `[auto: ${timer} / ${rounds}]` : '';
+    if (manualText && autoPart) return `${manualText} ${autoPart}`;
+    return manualText || autoPart;
+  };
 
   const toggleVideo = (exerciseKey) => {
     setExpandedVideos(prev => ({
@@ -241,29 +237,23 @@ const WorkoutLog = ({ accessToken, sheetId, onSheetTitleLoaded, onAuthRequired, 
   };
 
   const openFocusedSection = (sectionName, sectionPrescription, exercises) => {
-    const statsKey = getSectionFocusStatsKey(selectedDate, sectionName);
-    const savedStats = sectionFocusStats[statsKey] || { stopwatchSeconds: 0, roundCount: 0 };
+    const parsedStats = getSectionAutoStats(exercises[0]?.['Section Score'] || '');
+    const timerParts = parsedStats.timer ? parsedStats.timer.split(':').map(Number) : [];
+    const stopwatchSeconds = timerParts.length === 3
+      ? (timerParts[0] * 3600) + (timerParts[1] * 60) + timerParts[2]
+      : timerParts.length === 2
+        ? (timerParts[0] * 60) + timerParts[1]
+        : 0;
 
     setFocusedSectionName(sectionName);
     setFocusedSectionPrescription(sectionPrescription || '');
     setFocusedSectionExercises(exercises);
-    setSectionStopwatchSeconds(savedStats.stopwatchSeconds || 0);
+    setSectionStopwatchSeconds(stopwatchSeconds);
     setSectionStopwatchRunning(false);
-    setSectionRoundCount(savedStats.roundCount || 0);
+    setSectionRoundCount(parsedStats.rounds || 0);
   };
 
   const closeFocusedSection = () => {
-    if (focusedSectionName) {
-      const statsKey = getSectionFocusStatsKey(selectedDate, focusedSectionName);
-      setSectionFocusStats(prev => ({
-        ...prev,
-        [statsKey]: {
-          stopwatchSeconds: sectionStopwatchSeconds,
-          roundCount: sectionRoundCount,
-        }
-      }));
-    }
-
     setFocusedSectionName(null);
     setFocusedSectionPrescription('');
     setFocusedSectionExercises([]);
@@ -859,6 +849,73 @@ const WorkoutLog = ({ accessToken, sheetId, onSheetTitleLoaded, onAuthRequired, 
     }
   };
 
+  const updateFocusedSectionStats = async () => {
+    if (!focusedSectionName || focusedSectionExercises.length === 0) return;
+
+    const timerText = formatStopwatchTime(sectionStopwatchSeconds);
+    const parsedStats = getSectionAutoStats(focusedSectionExercises[0]?.['Section Score'] || '');
+    const nextSectionScore = buildSectionScoreValue(parsedStats.manualText, timerText, sectionRoundCount);
+    const sectionRowNumbers = focusedSectionExercises.map(exercise => exercise.__sheetRowNumber).filter(Boolean);
+
+    if (sectionRowNumbers.length === 0) return;
+
+    try {
+      await ensureSheetsApiReady();
+
+      const response = await gapi.client.sheets.spreadsheets.values.get({
+        spreadsheetId: sheetId,
+        range: 'WorkoutLog!A1:Z1',
+      });
+
+      const headers = response.result.values[0];
+      let sectionScoreColumnIndex = headers.indexOf('Section Score');
+
+      if (sectionScoreColumnIndex === -1) {
+        sectionScoreColumnIndex = headers.length;
+        await gapi.client.sheets.spreadsheets.values.update({
+          spreadsheetId: sheetId,
+          range: `WorkoutLog!${String.fromCharCode(65 + sectionScoreColumnIndex)}1`,
+          valueInputOption: 'RAW',
+          resource: {
+            values: [['Section Score']]
+          }
+        });
+      }
+
+      const columnLetter = String.fromCharCode(65 + sectionScoreColumnIndex);
+      const requests = sectionRowNumbers.map(rowNumber => gapi.client.sheets.spreadsheets.values.update({
+        spreadsheetId: sheetId,
+        range: `WorkoutLog!${columnLetter}${rowNumber}`,
+        valueInputOption: 'RAW',
+        resource: {
+          values: [[nextSectionScore]]
+        }
+      }));
+
+      await Promise.all(requests);
+
+      setWorkouts(prev => prev.map(workout =>
+        sectionRowNumbers.includes(workout.__sheetRowNumber)
+          ? { ...workout, ['Section Score']: nextSectionScore }
+          : workout
+      ));
+      setFocusedSectionExercises(prev => prev.map(exercise => ({ ...exercise, ['Section Score']: nextSectionScore })));
+    } catch (err) {
+      console.error('Error saving focused section stats:', err);
+      alert(`Error saving focused section stats: ${err.result?.error?.message || err.message}`);
+    }
+  };
+
+  useEffect(() => {
+    if (!focusedSectionName) return;
+
+    const timeoutId = window.setTimeout(() => {
+      updateFocusedSectionStats();
+    }, 400);
+
+    return () => window.clearTimeout(timeoutId);
+  }, [focusedSectionName, sectionStopwatchSeconds, sectionRoundCount]);
+
   if (focusedSectionName) {
     return (
       <div style={{
@@ -1166,25 +1223,28 @@ const WorkoutLog = ({ accessToken, sheetId, onSheetTitleLoaded, onAuthRequired, 
                             ▶
                           </button>
                         </div>
-                        {(sectionPrescription || sectionFocusStats[getSectionFocusStatsKey(selectedDate, sectionName)]) && (
-                          <div style={{ marginBottom: '10px' }}>
-                            {sectionPrescription && (
-                              <p style={{
-                                fontSize: '0.9em',
-                                color: '#aaa',
-                                marginBottom: '4px',
-                                fontStyle: 'italic'
-                              }}>
-                                {sectionPrescription}
-                              </p>
-                            )}
-                            {sectionFocusStats[getSectionFocusStatsKey(selectedDate, sectionName)] && (
-                              <div style={{ fontSize: '0.82em', color: '#8aa0c8' }}>
-                                {formatStopwatchTime(sectionFocusStats[getSectionFocusStatsKey(selectedDate, sectionName)].stopwatchSeconds || 0)} • {sectionFocusStats[getSectionFocusStatsKey(selectedDate, sectionName)].roundCount || 0} rounds
-                              </div>
-                            )}
-                          </div>
-                        )}
+                        {(() => {
+                          const autoStats = getSectionAutoStats(exercises[0]?.['Section Score'] || '');
+                          return (sectionPrescription || autoStats.timer) && (
+                            <div style={{ marginBottom: '10px' }}>
+                              {sectionPrescription && (
+                                <p style={{
+                                  fontSize: '0.9em',
+                                  color: '#aaa',
+                                  marginBottom: autoStats.timer ? '4px' : '0',
+                                  fontStyle: 'italic'
+                                }}>
+                                  {sectionPrescription}
+                                </p>
+                              )}
+                              {autoStats.timer && (
+                                <div style={{ fontSize: '0.82em', color: '#8aa0c8' }}>
+                                  {autoStats.timer} • {autoStats.rounds} rounds
+                                </div>
+                              )}
+                            </div>
+                          );
+                        })()}
                         {exercises.map((exercise, exerciseIndex) => {
                           const videoLink = exerciseVideoMap[exercise.Exercise];
                           const details = exerciseDetailsMap[exercise.Exercise] || {};

--- a/src/components/workoutLog.jsx
+++ b/src/components/workoutLog.jsx
@@ -855,15 +855,15 @@ const WorkoutLog = ({ accessToken, sheetId, onSheetTitleLoaded, onAuthRequired, 
             <div
               onClick={() => setSectionStopwatchRunning(prev => !prev)}
               style={{
-                backgroundColor: '#1a1a1a',
-                border: '1px solid #333',
+                backgroundColor: sectionStopwatchRunning ? '#b9e97c' : '#1a1a1a',
+                border: `1px solid ${sectionStopwatchRunning ? '#b9e97c' : '#333'}`,
                 borderRadius: '10px',
                 padding: '14px',
-                cursor: 'pointer'
+                cursor: 'pointer',
+                color: sectionStopwatchRunning ? '#111' : '#fff'
               }}
             >
-              <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: '10px', marginBottom: '4px' }}>
-                <div style={{ color: '#999', fontSize: '0.8em' }}>Stopwatch</div>
+              <div style={{ display: 'flex', justifyContent: 'flex-end', marginBottom: '4px' }}>
                 <span
                   onClick={(event) => {
                     event.stopPropagation();
@@ -880,8 +880,8 @@ const WorkoutLog = ({ accessToken, sheetId, onSheetTitleLoaded, onAuthRequired, 
                     width: '28px',
                     height: '28px',
                     borderRadius: '999px',
-                    border: '1px solid #444',
-                    color: '#bbb',
+                    border: `1px solid ${sectionStopwatchRunning ? '#86b85f' : '#444'}`,
+                    color: sectionStopwatchRunning ? '#335214' : '#bbb',
                     fontSize: '0.95em'
                   }}
                 >
@@ -889,9 +889,6 @@ const WorkoutLog = ({ accessToken, sheetId, onSheetTitleLoaded, onAuthRequired, 
                 </span>
               </div>
               <div style={{ fontSize: '2.1em', fontWeight: 700 }}>{formatStopwatchTime(sectionStopwatchSeconds)}</div>
-              <div style={{ marginTop: '4px', color: sectionStopwatchRunning ? '#8bc34a' : '#888', fontSize: '0.8em' }}>
-                {sectionStopwatchRunning ? 'Running' : 'Stopped'}
-              </div>
             </div>
             <button
               onClick={() => setSectionRoundCount(prev => prev + 1)}
@@ -905,8 +902,7 @@ const WorkoutLog = ({ accessToken, sheetId, onSheetTitleLoaded, onAuthRequired, 
                 cursor: 'pointer'
               }}
             >
-              <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: '10px', marginBottom: '4px' }}>
-                <div style={{ color: '#9fb3ff', fontSize: '0.8em' }}>Rounds</div>
+              <div style={{ display: 'flex', justifyContent: 'flex-end', marginBottom: '4px' }}>
                 <span
                   onClick={(event) => {
                     event.stopPropagation();

--- a/src/components/workoutLog.jsx
+++ b/src/components/workoutLog.jsx
@@ -850,47 +850,48 @@ const WorkoutLog = ({ accessToken, sheetId, onSheetTitleLoaded, onAuthRequired, 
             display: 'grid',
             gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))',
             gap: '12px',
-            marginBottom: '24px'
+            marginBottom: '20px'
           }}>
-            <div style={{ backgroundColor: '#1a1a1a', border: '1px solid #333', borderRadius: '10px', padding: '16px' }}>
-              <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: '10px', marginBottom: '6px' }}>
-                <div style={{ color: '#999', fontSize: '0.85em' }}>Stopwatch</div>
-                <button
-                  onClick={() => {
+            <div
+              onClick={() => setSectionStopwatchRunning(prev => !prev)}
+              style={{
+                backgroundColor: '#1a1a1a',
+                border: '1px solid #333',
+                borderRadius: '10px',
+                padding: '14px',
+                cursor: 'pointer'
+              }}
+            >
+              <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: '10px', marginBottom: '4px' }}>
+                <div style={{ color: '#999', fontSize: '0.8em' }}>Stopwatch</div>
+                <span
+                  onClick={(event) => {
+                    event.stopPropagation();
                     setSectionStopwatchRunning(false);
                     setSectionStopwatchSeconds(0);
                   }}
+                  role="button"
                   title="Reset timer"
                   aria-label="Reset timer"
                   style={{
-                    padding: '2px 8px',
-                    fontSize: '0.9em',
-                    backgroundColor: '#2a2a2a',
-                    color: '#bbb',
-                    border: '1px solid #444',
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    width: '28px',
+                    height: '28px',
                     borderRadius: '999px',
-                    cursor: 'pointer'
+                    border: '1px solid #444',
+                    color: '#bbb',
+                    fontSize: '0.95em'
                   }}
                 >
                   ↺
-                </button>
+                </span>
               </div>
-              <div style={{ fontSize: '2em', fontWeight: 700, marginBottom: '10px' }}>{formatStopwatchTime(sectionStopwatchSeconds)}</div>
-              <button
-                onClick={() => setSectionStopwatchRunning(prev => !prev)}
-                style={{
-                  width: '100%',
-                  padding: '0.8em 1em',
-                  fontSize: '1em',
-                  backgroundColor: sectionStopwatchRunning ? '#8bc34a' : '#2a2a2a',
-                  color: sectionStopwatchRunning ? '#111' : '#fff',
-                  border: '1px solid #444',
-                  borderRadius: '8px',
-                  cursor: 'pointer'
-                }}
-              >
-                {sectionStopwatchRunning ? 'Pause' : 'Start'}
-              </button>
+              <div style={{ fontSize: '2.1em', fontWeight: 700 }}>{formatStopwatchTime(sectionStopwatchSeconds)}</div>
+              <div style={{ marginTop: '4px', color: sectionStopwatchRunning ? '#8bc34a' : '#888', fontSize: '0.8em' }}>
+                {sectionStopwatchRunning ? 'Running' : 'Stopped'}
+              </div>
             </div>
             <button
               onClick={() => setSectionRoundCount(prev => prev + 1)}
@@ -898,14 +899,14 @@ const WorkoutLog = ({ accessToken, sheetId, onSheetTitleLoaded, onAuthRequired, 
                 backgroundColor: '#1d2a44',
                 border: '1px solid #3f5ea8',
                 borderRadius: '10px',
-                padding: '16px',
+                padding: '14px',
                 color: '#fff',
                 textAlign: 'left',
                 cursor: 'pointer'
               }}
             >
-              <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: '10px', marginBottom: '6px' }}>
-                <div style={{ color: '#9fb3ff', fontSize: '0.85em' }}>Rounds</div>
+              <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: '10px', marginBottom: '4px' }}>
+                <div style={{ color: '#9fb3ff', fontSize: '0.8em' }}>Rounds</div>
                 <span
                   onClick={(event) => {
                     event.stopPropagation();
@@ -930,7 +931,6 @@ const WorkoutLog = ({ accessToken, sheetId, onSheetTitleLoaded, onAuthRequired, 
                 </span>
               </div>
               <div style={{ fontSize: '2.8em', fontWeight: 700 }}>{sectionRoundCount}</div>
-              <div style={{ marginTop: '8px', color: '#c9d5ff', fontSize: '0.9em' }}>Tap this card to add one round</div>
             </button>
           </div>
 

--- a/src/components/workoutLog.jsx
+++ b/src/components/workoutLog.jsx
@@ -853,7 +853,11 @@ const WorkoutLog = ({ accessToken, sheetId, onSheetTitleLoaded, onAuthRequired, 
     if (!focusedSectionName || focusedSectionExercises.length === 0) return;
 
     const timerText = formatStopwatchTime(sectionStopwatchSeconds);
-    const parsedStats = getSectionAutoStats(focusedSectionExercises[0]?.['Section Score'] || '');
+    const currentWorkoutSection = workouts.find(workout =>
+      workout.Section === focusedSectionName &&
+      workout.Date === toDateKey(selectedDate)
+    );
+    const parsedStats = getSectionAutoStats(currentWorkoutSection?.['Section Score'] || focusedSectionExercises[0]?.['Section Score'] || '');
     const nextSectionScore = buildSectionScoreValue(parsedStats.manualText, timerText, sectionRoundCount);
     const sectionRowNumbers = focusedSectionExercises.map(exercise => exercise.__sheetRowNumber).filter(Boolean);
 

--- a/src/components/workoutLog.jsx
+++ b/src/components/workoutLog.jsx
@@ -1,5 +1,11 @@
 import { useState, useEffect, useRef } from 'preact/hooks';
 import { validateSpreadsheetSchema, formatValidationErrors } from '../utils/schemaValidator';
+import {
+  getSectionAutoStats,
+  buildSectionScoreValue,
+  formatStopwatchTime,
+  parseStopwatchTimeToSeconds,
+} from '../utils/sectionScore';
 
 // We access gapi via the window object, as it's loaded from a script tag.
 const gapi = window.gapi;
@@ -145,25 +151,6 @@ const WorkoutLog = ({ accessToken, sheetId, onSheetTitleLoaded, onAuthRequired, 
     return () => window.clearInterval(intervalId);
   }, [sectionStopwatchRunning]);
 
-  const getSectionAutoStats = (sectionScoreValue = '') => {
-    const match = sectionScoreValue.match(/\[auto:\s*(\d{2}:\d{2}(?::\d{2})?)\s*\/\s*(\d+)\]$/);
-    if (!match) {
-      return { timer: '', rounds: 0, manualText: sectionScoreValue.trim() };
-    }
-
-    return {
-      timer: match[1],
-      rounds: Number(match[2]) || 0,
-      manualText: sectionScoreValue.replace(match[0], '').trim(),
-    };
-  };
-
-  const buildSectionScoreValue = (manualText = '', timer = '', rounds = 0) => {
-    const autoPart = timer ? `[auto: ${timer} / ${rounds}]` : '';
-    if (manualText && autoPart) return `${manualText} ${autoPart}`;
-    return manualText || autoPart;
-  };
-
   const toggleVideo = (exerciseKey) => {
     setExpandedVideos(prev => ({
       ...prev,
@@ -223,28 +210,10 @@ const WorkoutLog = ({ accessToken, sheetId, onSheetTitleLoaded, onAuthRequired, 
     setViewMode('week');
   };
 
-  const formatStopwatchTime = (totalSeconds) => {
-    const hours = Math.floor(totalSeconds / 3600);
-    const minutes = Math.floor((totalSeconds % 3600) / 60);
-    const seconds = totalSeconds % 60;
-
-    const mm = String(minutes).padStart(2, '0');
-    const ss = String(seconds).padStart(2, '0');
-    if (hours > 0) {
-      return `${String(hours).padStart(2, '0')}:${mm}:${ss}`;
-    }
-    return `${mm}:${ss}`;
-  };
-
   const openFocusedSection = (sectionName, sectionPrescription, exercises) => {
     const lastExercise = exercises[exercises.length - 1];
     const parsedStats = getSectionAutoStats(lastExercise?.['Section Score'] || '');
-    const timerParts = parsedStats.timer ? parsedStats.timer.split(':').map(Number) : [];
-    const stopwatchSeconds = timerParts.length === 3
-      ? (timerParts[0] * 3600) + (timerParts[1] * 60) + timerParts[2]
-      : timerParts.length === 2
-        ? (timerParts[0] * 60) + timerParts[1]
-        : 0;
+    const stopwatchSeconds = parseStopwatchTimeToSeconds(parsedStats.timer);
 
     setFocusedSectionName(sectionName);
     setFocusedSectionPrescription(sectionPrescription || '');

--- a/src/components/workoutLog.jsx
+++ b/src/components/workoutLog.jsx
@@ -3,6 +3,7 @@ import { validateSpreadsheetSchema, formatValidationErrors } from '../utils/sche
 
 // We access gapi via the window object, as it's loaded from a script tag.
 const gapi = window.gapi;
+const SECTION_FOCUS_STATS_KEY = 'workout_section_focus_stats';
 
 const WorkoutLog = ({ accessToken, sheetId, onSheetTitleLoaded, onAuthRequired, onSessionExpired }) => {
   const [workouts, setWorkouts] = useState([]);
@@ -127,6 +128,7 @@ const WorkoutLog = ({ accessToken, sheetId, onSheetTitleLoaded, onAuthRequired, 
   const [sectionStopwatchSeconds, setSectionStopwatchSeconds] = useState(0);
   const [sectionStopwatchRunning, setSectionStopwatchRunning] = useState(false);
   const [sectionRoundCount, setSectionRoundCount] = useState(0);
+  const [sectionFocusStats, setSectionFocusStats] = useState({});
   const weekDragStateRef = useRef({
     pointerId: null,
     startX: 0,
@@ -144,6 +146,27 @@ const WorkoutLog = ({ accessToken, sheetId, onSheetTitleLoaded, onAuthRequired, 
 
     return () => window.clearInterval(intervalId);
   }, [sectionStopwatchRunning]);
+
+  const getSectionFocusStatsKey = (date, sectionName) => `${toDateKey(date)}::${sectionName}`;
+
+  useEffect(() => {
+    try {
+      const raw = localStorage.getItem(SECTION_FOCUS_STATS_KEY);
+      if (raw) {
+        setSectionFocusStats(JSON.parse(raw));
+      }
+    } catch (err) {
+      console.error('Error loading section focus stats:', err);
+    }
+  }, []);
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(SECTION_FOCUS_STATS_KEY, JSON.stringify(sectionFocusStats));
+    } catch (err) {
+      console.error('Error saving section focus stats:', err);
+    }
+  }, [sectionFocusStats]);
 
   const toggleVideo = (exerciseKey) => {
     setExpandedVideos(prev => ({
@@ -218,15 +241,29 @@ const WorkoutLog = ({ accessToken, sheetId, onSheetTitleLoaded, onAuthRequired, 
   };
 
   const openFocusedSection = (sectionName, sectionPrescription, exercises) => {
+    const statsKey = getSectionFocusStatsKey(selectedDate, sectionName);
+    const savedStats = sectionFocusStats[statsKey] || { stopwatchSeconds: 0, roundCount: 0 };
+
     setFocusedSectionName(sectionName);
     setFocusedSectionPrescription(sectionPrescription || '');
     setFocusedSectionExercises(exercises);
-    setSectionStopwatchSeconds(0);
+    setSectionStopwatchSeconds(savedStats.stopwatchSeconds || 0);
     setSectionStopwatchRunning(false);
-    setSectionRoundCount(0);
+    setSectionRoundCount(savedStats.roundCount || 0);
   };
 
   const closeFocusedSection = () => {
+    if (focusedSectionName) {
+      const statsKey = getSectionFocusStatsKey(selectedDate, focusedSectionName);
+      setSectionFocusStats(prev => ({
+        ...prev,
+        [statsKey]: {
+          stopwatchSeconds: sectionStopwatchSeconds,
+          roundCount: sectionRoundCount,
+        }
+      }));
+    }
+
     setFocusedSectionName(null);
     setFocusedSectionPrescription('');
     setFocusedSectionExercises([]);
@@ -1129,15 +1166,24 @@ const WorkoutLog = ({ accessToken, sheetId, onSheetTitleLoaded, onAuthRequired, 
                             ▶
                           </button>
                         </div>
-                        {sectionPrescription && (
-                          <p style={{
-                            fontSize: '0.9em',
-                            color: '#aaa',
-                            marginBottom: '10px',
-                            fontStyle: 'italic'
-                          }}>
-                            {sectionPrescription}
-                          </p>
+                        {(sectionPrescription || sectionFocusStats[getSectionFocusStatsKey(selectedDate, sectionName)]) && (
+                          <div style={{ marginBottom: '10px' }}>
+                            {sectionPrescription && (
+                              <p style={{
+                                fontSize: '0.9em',
+                                color: '#aaa',
+                                marginBottom: '4px',
+                                fontStyle: 'italic'
+                              }}>
+                                {sectionPrescription}
+                              </p>
+                            )}
+                            {sectionFocusStats[getSectionFocusStatsKey(selectedDate, sectionName)] && (
+                              <div style={{ fontSize: '0.82em', color: '#8aa0c8' }}>
+                                {formatStopwatchTime(sectionFocusStats[getSectionFocusStatsKey(selectedDate, sectionName)].stopwatchSeconds || 0)} • {sectionFocusStats[getSectionFocusStatsKey(selectedDate, sectionName)].roundCount || 0} rounds
+                              </div>
+                            )}
+                          </div>
                         )}
                         {exercises.map((exercise, exerciseIndex) => {
                           const videoLink = exerciseVideoMap[exercise.Exercise];

--- a/src/components/workoutLog.jsx
+++ b/src/components/workoutLog.jsx
@@ -237,7 +237,8 @@ const WorkoutLog = ({ accessToken, sheetId, onSheetTitleLoaded, onAuthRequired, 
   };
 
   const openFocusedSection = (sectionName, sectionPrescription, exercises) => {
-    const parsedStats = getSectionAutoStats(exercises[0]?.['Section Score'] || '');
+    const lastExercise = exercises[exercises.length - 1];
+    const parsedStats = getSectionAutoStats(lastExercise?.['Section Score'] || '');
     const timerParts = parsedStats.timer ? parsedStats.timer.split(':').map(Number) : [];
     const stopwatchSeconds = timerParts.length === 3
       ? (timerParts[0] * 3600) + (timerParts[1] * 60) + timerParts[2]
@@ -853,15 +854,13 @@ const WorkoutLog = ({ accessToken, sheetId, onSheetTitleLoaded, onAuthRequired, 
     if (!focusedSectionName || focusedSectionExercises.length === 0) return;
 
     const timerText = formatStopwatchTime(sectionStopwatchSeconds);
-    const currentWorkoutSection = workouts.find(workout =>
-      workout.Section === focusedSectionName &&
-      workout.Date === toDateKey(selectedDate)
-    );
-    const parsedStats = getSectionAutoStats(currentWorkoutSection?.['Section Score'] || focusedSectionExercises[0]?.['Section Score'] || '');
+    const lastFocusedExercise = focusedSectionExercises[focusedSectionExercises.length - 1];
+    const lastFocusedRowNumber = lastFocusedExercise?.__sheetRowNumber;
+    const currentWorkoutSection = workouts.find(workout => workout.__sheetRowNumber === lastFocusedRowNumber);
+    const parsedStats = getSectionAutoStats(currentWorkoutSection?.['Section Score'] || lastFocusedExercise?.['Section Score'] || '');
     const nextSectionScore = buildSectionScoreValue(parsedStats.manualText, timerText, sectionRoundCount);
-    const sectionRowNumbers = focusedSectionExercises.map(exercise => exercise.__sheetRowNumber).filter(Boolean);
 
-    if (sectionRowNumbers.length === 0) return;
+    if (!lastFocusedRowNumber) return;
 
     try {
       await ensureSheetsApiReady();
@@ -887,23 +886,25 @@ const WorkoutLog = ({ accessToken, sheetId, onSheetTitleLoaded, onAuthRequired, 
       }
 
       const columnLetter = String.fromCharCode(65 + sectionScoreColumnIndex);
-      const requests = sectionRowNumbers.map(rowNumber => gapi.client.sheets.spreadsheets.values.update({
+      await gapi.client.sheets.spreadsheets.values.update({
         spreadsheetId: sheetId,
-        range: `WorkoutLog!${columnLetter}${rowNumber}`,
+        range: `WorkoutLog!${columnLetter}${lastFocusedRowNumber}`,
         valueInputOption: 'RAW',
         resource: {
           values: [[nextSectionScore]]
         }
-      }));
-
-      await Promise.all(requests);
+      });
 
       setWorkouts(prev => prev.map(workout =>
-        sectionRowNumbers.includes(workout.__sheetRowNumber)
+        workout.__sheetRowNumber === lastFocusedRowNumber
           ? { ...workout, ['Section Score']: nextSectionScore }
           : workout
       ));
-      setFocusedSectionExercises(prev => prev.map(exercise => ({ ...exercise, ['Section Score']: nextSectionScore })));
+      setFocusedSectionExercises(prev => prev.map((exercise, index) =>
+        index === prev.length - 1
+          ? { ...exercise, ['Section Score']: nextSectionScore }
+          : exercise
+      ));
     } catch (err) {
       console.error('Error saving focused section stats:', err);
       alert(`Error saving focused section stats: ${err.result?.error?.message || err.message}`);
@@ -1228,7 +1229,7 @@ const WorkoutLog = ({ accessToken, sheetId, onSheetTitleLoaded, onAuthRequired, 
                           </button>
                         </div>
                         {(() => {
-                          const autoStats = getSectionAutoStats(exercises[0]?.['Section Score'] || '');
+                          const autoStats = getSectionAutoStats(exercises[exercises.length - 1]?.['Section Score'] || '');
                           return (sectionPrescription || autoStats.timer) && (
                             <div style={{ marginBottom: '10px' }}>
                               {sectionPrescription && (

--- a/src/components/workoutLog.jsx
+++ b/src/components/workoutLog.jsx
@@ -121,6 +121,12 @@ const WorkoutLog = ({ accessToken, sheetId, onSheetTitleLoaded, onAuthRequired, 
   const [currentMonth, setCurrentMonth] = useState(new Date());
   const [weekDragOffset, setWeekDragOffset] = useState(0);
   const [weekSlideTransition, setWeekSlideTransition] = useState('transform 0.18s ease-out');
+  const [focusedSectionName, setFocusedSectionName] = useState(null);
+  const [focusedSectionExercises, setFocusedSectionExercises] = useState([]);
+  const [focusedSectionPrescription, setFocusedSectionPrescription] = useState('');
+  const [sectionStopwatchSeconds, setSectionStopwatchSeconds] = useState(0);
+  const [sectionStopwatchRunning, setSectionStopwatchRunning] = useState(false);
+  const [sectionRoundCount, setSectionRoundCount] = useState(0);
   const weekDragStateRef = useRef({
     pointerId: null,
     startX: 0,
@@ -128,6 +134,16 @@ const WorkoutLog = ({ accessToken, sheetId, onSheetTitleLoaded, onAuthRequired, 
     dragging: false,
     navigated: false,
   });
+
+  useEffect(() => {
+    if (!sectionStopwatchRunning) return;
+
+    const intervalId = window.setInterval(() => {
+      setSectionStopwatchSeconds(prev => prev + 1);
+    }, 1000);
+
+    return () => window.clearInterval(intervalId);
+  }, [sectionStopwatchRunning]);
 
   const toggleVideo = (exerciseKey) => {
     setExpandedVideos(prev => ({
@@ -186,6 +202,37 @@ const WorkoutLog = ({ accessToken, sheetId, onSheetTitleLoaded, onAuthRequired, 
   const handleDayClick = (date) => {
     setSelectedDate(date);
     setViewMode('week');
+  };
+
+  const formatStopwatchTime = (totalSeconds) => {
+    const hours = Math.floor(totalSeconds / 3600);
+    const minutes = Math.floor((totalSeconds % 3600) / 60);
+    const seconds = totalSeconds % 60;
+
+    const mm = String(minutes).padStart(2, '0');
+    const ss = String(seconds).padStart(2, '0');
+    if (hours > 0) {
+      return `${String(hours).padStart(2, '0')}:${mm}:${ss}`;
+    }
+    return `${mm}:${ss}`;
+  };
+
+  const openFocusedSection = (sectionName, sectionPrescription, exercises) => {
+    setFocusedSectionName(sectionName);
+    setFocusedSectionPrescription(sectionPrescription || '');
+    setFocusedSectionExercises(exercises);
+    setSectionStopwatchSeconds(0);
+    setSectionStopwatchRunning(false);
+    setSectionRoundCount(0);
+  };
+
+  const closeFocusedSection = () => {
+    setFocusedSectionName(null);
+    setFocusedSectionPrescription('');
+    setFocusedSectionExercises([]);
+    setSectionStopwatchRunning(false);
+    setSectionStopwatchSeconds(0);
+    setSectionRoundCount(0);
   };
 
   const changeMonth = (offset) => {
@@ -775,6 +822,153 @@ const WorkoutLog = ({ accessToken, sheetId, onSheetTitleLoaded, onAuthRequired, 
     }
   };
 
+  if (focusedSectionName) {
+    return (
+      <div style={{
+        position: 'fixed',
+        inset: 0,
+        zIndex: 2000,
+        backgroundColor: '#111',
+        color: '#fff',
+        overflowY: 'auto',
+        padding: '20px'
+      }}>
+        <div style={{ maxWidth: '900px', margin: '0 auto' }}>
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', gap: '12px', marginBottom: '16px' }}>
+            <div>
+              <h2 style={{ margin: 0, color: '#8bc34a' }}>{focusedSectionName}</h2>
+              {focusedSectionPrescription && (
+                <p style={{ marginTop: '6px', color: '#aaa', fontStyle: 'italic' }}>{focusedSectionPrescription}</p>
+              )}
+            </div>
+            <button onClick={closeFocusedSection} style={{ fontSize: '0.95em', padding: '0.6em 1em' }}>
+              Exit
+            </button>
+          </div>
+
+          <div style={{
+            display: 'grid',
+            gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))',
+            gap: '12px',
+            marginBottom: '24px'
+          }}>
+            <div style={{ backgroundColor: '#1a1a1a', border: '1px solid #333', borderRadius: '10px', padding: '16px' }}>
+              <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: '10px', marginBottom: '6px' }}>
+                <div style={{ color: '#999', fontSize: '0.85em' }}>Stopwatch</div>
+                <button
+                  onClick={() => {
+                    setSectionStopwatchRunning(false);
+                    setSectionStopwatchSeconds(0);
+                  }}
+                  title="Reset timer"
+                  aria-label="Reset timer"
+                  style={{
+                    padding: '2px 8px',
+                    fontSize: '0.9em',
+                    backgroundColor: '#2a2a2a',
+                    color: '#bbb',
+                    border: '1px solid #444',
+                    borderRadius: '999px',
+                    cursor: 'pointer'
+                  }}
+                >
+                  ↺
+                </button>
+              </div>
+              <div style={{ fontSize: '2em', fontWeight: 700, marginBottom: '10px' }}>{formatStopwatchTime(sectionStopwatchSeconds)}</div>
+              <button
+                onClick={() => setSectionStopwatchRunning(prev => !prev)}
+                style={{
+                  width: '100%',
+                  padding: '0.8em 1em',
+                  fontSize: '1em',
+                  backgroundColor: sectionStopwatchRunning ? '#8bc34a' : '#2a2a2a',
+                  color: sectionStopwatchRunning ? '#111' : '#fff',
+                  border: '1px solid #444',
+                  borderRadius: '8px',
+                  cursor: 'pointer'
+                }}
+              >
+                {sectionStopwatchRunning ? 'Pause' : 'Start'}
+              </button>
+            </div>
+            <button
+              onClick={() => setSectionRoundCount(prev => prev + 1)}
+              style={{
+                backgroundColor: '#1d2a44',
+                border: '1px solid #3f5ea8',
+                borderRadius: '10px',
+                padding: '16px',
+                color: '#fff',
+                textAlign: 'left',
+                cursor: 'pointer'
+              }}
+            >
+              <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: '10px', marginBottom: '6px' }}>
+                <div style={{ color: '#9fb3ff', fontSize: '0.85em' }}>Rounds</div>
+                <span
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    setSectionRoundCount(0);
+                  }}
+                  role="button"
+                  title="Reset rounds"
+                  aria-label="Reset rounds"
+                  style={{
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    width: '28px',
+                    height: '28px',
+                    borderRadius: '999px',
+                    border: '1px solid #3f5ea8',
+                    color: '#c9d5ff',
+                    fontSize: '0.95em'
+                  }}
+                >
+                  ↺
+                </span>
+              </div>
+              <div style={{ fontSize: '2.8em', fontWeight: 700 }}>{sectionRoundCount}</div>
+              <div style={{ marginTop: '8px', color: '#c9d5ff', fontSize: '0.9em' }}>Tap this card to add one round</div>
+            </button>
+          </div>
+
+          <div>
+            {focusedSectionExercises.map((exercise, exerciseIndex) => (
+              <div
+                key={`${focusedSectionName}-${exerciseIndex}`}
+                style={{
+                  marginBottom: '12px',
+                  padding: '14px',
+                  backgroundColor: '#1a1a1a',
+                  borderRadius: '8px',
+                  border: '1px solid #333'
+                }}
+              >
+                {Object.entries(exercise).map(([key, value]) => {
+                  if (key.startsWith('__')) return null;
+                  if (key === 'Date' || key === 'Section' || key === 'Section Prescription' || key === 'Day' || key === 'Section Score') return null;
+                  if (!value && key !== 'Notes') return null;
+
+                  if (key === 'Exercise') {
+                    return <div key={key} style={{ fontSize: '1.15em', fontWeight: 700, marginBottom: '8px' }}>{value}</div>;
+                  }
+
+                  if (key === 'Notes') {
+                    return value ? <div key={key} style={{ color: '#aaa', fontStyle: 'italic' }}>{value}</div> : null;
+                  }
+
+                  return <div key={key} style={{ marginBottom: '4px', color: '#ddd' }}>{value}</div>;
+                })}
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div>
       <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '20px' }}>
@@ -904,15 +1098,39 @@ const WorkoutLog = ({ accessToken, sheetId, onSheetTitleLoaded, onAuthRequired, 
 
                     return (
                       <div key={sectionName} style={{ marginBottom: '20px' }}>
-                        <h4 style={{
-                          fontSize: '1.1em',
-                          marginBottom: '5px',
-                          color: '#8bc34a',
+                        <div style={{
+                          display: 'flex',
+                          justifyContent: 'space-between',
+                          alignItems: 'center',
+                          gap: '10px',
                           borderBottom: '1px solid #444',
-                          paddingBottom: '5px'
+                          paddingBottom: '5px',
+                          marginBottom: '5px'
                         }}>
-                          {sectionName}
-                        </h4>
+                          <h4 style={{
+                            fontSize: '1.1em',
+                            margin: 0,
+                            color: '#8bc34a'
+                          }}>
+                            {sectionName}
+                          </h4>
+                          <button
+                            onClick={() => openFocusedSection(sectionName, sectionPrescription, exercises)}
+                            title={`Focus ${sectionName}`}
+                            aria-label={`Focus ${sectionName}`}
+                            style={{
+                              padding: '4px 10px',
+                              fontSize: '0.9em',
+                              backgroundColor: '#333',
+                              color: '#fff',
+                              border: '1px solid #444',
+                              borderRadius: '6px',
+                              cursor: 'pointer'
+                            }}
+                          >
+                            ▶
+                          </button>
+                        </div>
                         {sectionPrescription && (
                           <p style={{
                             fontSize: '0.9em',

--- a/src/components/workoutLog.jsx
+++ b/src/components/workoutLog.jsx
@@ -1257,6 +1257,7 @@ const WorkoutLog = ({ accessToken, sheetId, onSheetTitleLoaded, onAuthRequired, 
                           const showVideo = expandedVideos[exerciseKey];
                           const notesValue = exercise.Notes || '';
                           const sectionScoreValue = exercise['Section Score'] || '';
+                          const parsedSectionScore = getSectionAutoStats(sectionScoreValue);
                           const isEditingSectionScore = exerciseKey in editingSectionScores;
                           const isSavingSectionScore = exerciseKey in savingSectionScores;
                           const canEditSectionScore = !!accessToken;
@@ -1337,7 +1338,7 @@ const WorkoutLog = ({ accessToken, sheetId, onSheetTitleLoaded, onAuthRequired, 
                                               <button
                                                 onClick={() => setEditingSectionScores(prev => ({
                                                   ...prev,
-                                                  [exerciseKey]: sectionScoreValue
+                                                  [exerciseKey]: parsedSectionScore.manualText
                                                 }))}
                                                 title={sectionScoreValue ? 'Edit section score' : 'Add section score'}
                                                 aria-label={sectionScoreValue ? 'Edit section score' : 'Add section score'}
@@ -1466,7 +1467,7 @@ const WorkoutLog = ({ accessToken, sheetId, onSheetTitleLoaded, onAuthRequired, 
                                           />
                                           <div style={{ marginTop: '5px', display: 'flex', gap: '5px' }}>
                                             <button
-                                              onClick={() => updateSectionScore(sheetRowNumber, editingSectionScores[exerciseKey] || '', exerciseKey)}
+                                              onClick={() => updateSectionScore(sheetRowNumber, buildSectionScoreValue(editingSectionScores[exerciseKey] || '', parsedSectionScore.timer, parsedSectionScore.rounds), exerciseKey)}
                                               disabled={isSavingSectionScore}
                                               style={{
                                                 padding: '5px 10px',
@@ -1504,12 +1505,12 @@ const WorkoutLog = ({ accessToken, sheetId, onSheetTitleLoaded, onAuthRequired, 
                                         </div>
                                       ) : (
                                         <div style={{ marginTop: '5px' }}>
-                                          {sectionScoreValue && (
+                                          {parsedSectionScore.manualText && (
                                             <div style={{
                                               color: '#aaa',
                                               marginBottom: '4px'
                                             }}>
-                                              🕒 {sectionScoreValue}
+                                              🕒 {parsedSectionScore.manualText}
                                             </div>
                                           )}
                                         </div>

--- a/src/utils/sectionScore.js
+++ b/src/utils/sectionScore.js
@@ -1,0 +1,42 @@
+export const getSectionAutoStats = (sectionScoreValue = '') => {
+  const match = sectionScoreValue.match(/\[auto:\s*(\d{2}:\d{2}(?::\d{2})?)\s*\/\s*(\d+)\]$/);
+  if (!match) {
+    return { timer: '', rounds: 0, manualText: sectionScoreValue.trim() };
+  }
+
+  return {
+    timer: match[1],
+    rounds: Number(match[2]) || 0,
+    manualText: sectionScoreValue.replace(match[0], '').trim(),
+  };
+};
+
+export const buildSectionScoreValue = (manualText = '', timer = '', rounds = 0) => {
+  const autoPart = timer ? `[auto: ${timer} / ${rounds}]` : '';
+  if (manualText && autoPart) return `${manualText} ${autoPart}`;
+  return manualText || autoPart;
+};
+
+export const formatStopwatchTime = (totalSeconds) => {
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+
+  const mm = String(minutes).padStart(2, '0');
+  const ss = String(seconds).padStart(2, '0');
+  if (hours > 0) {
+    return `${String(hours).padStart(2, '0')}:${mm}:${ss}`;
+  }
+  return `${mm}:${ss}`;
+};
+
+export const parseStopwatchTimeToSeconds = (timerText = '') => {
+  const timerParts = timerText ? timerText.split(':').map(Number) : [];
+  if (timerParts.length === 3) {
+    return (timerParts[0] * 3600) + (timerParts[1] * 60) + timerParts[2];
+  }
+  if (timerParts.length === 2) {
+    return (timerParts[0] * 60) + timerParts[1];
+  }
+  return 0;
+};

--- a/src/utils/sectionScore.test.js
+++ b/src/utils/sectionScore.test.js
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest';
+import {
+  getSectionAutoStats,
+  buildSectionScoreValue,
+  formatStopwatchTime,
+  parseStopwatchTimeToSeconds,
+} from './sectionScore';
+
+describe('sectionScore helpers', () => {
+  describe('getSectionAutoStats', () => {
+    it('returns manual text only when there is no auto suffix', () => {
+      expect(getSectionAutoStats('Felt strong today')).toEqual({
+        timer: '',
+        rounds: 0,
+        manualText: 'Felt strong today',
+      });
+    });
+
+    it('parses auto-only score', () => {
+      expect(getSectionAutoStats('[auto: 00:05 / 5]')).toEqual({
+        timer: '00:05',
+        rounds: 5,
+        manualText: '',
+      });
+    });
+
+    it('parses manual text with auto suffix', () => {
+      expect(getSectionAutoStats('Nice pace [auto: 12:34 / 7]')).toEqual({
+        timer: '12:34',
+        rounds: 7,
+        manualText: 'Nice pace',
+      });
+    });
+
+    it('supports hour-long timer format', () => {
+      expect(getSectionAutoStats('Long one [auto: 01:02:03 / 9]')).toEqual({
+        timer: '01:02:03',
+        rounds: 9,
+        manualText: 'Long one',
+      });
+    });
+  });
+
+  describe('buildSectionScoreValue', () => {
+    it('returns manual text unchanged when no auto values are present', () => {
+      expect(buildSectionScoreValue('Manual only', '', 0)).toBe('Manual only');
+    });
+
+    it('returns only auto suffix when there is no manual text', () => {
+      expect(buildSectionScoreValue('', '00:05', 5)).toBe('[auto: 00:05 / 5]');
+    });
+
+    it('preserves manual text and appends auto suffix', () => {
+      expect(buildSectionScoreValue('Manual note', '00:05', 5)).toBe('Manual note [auto: 00:05 / 5]');
+    });
+  });
+
+  describe('stopwatch formatting/parsing', () => {
+    it('formats short durations as mm:ss', () => {
+      expect(formatStopwatchTime(65)).toBe('01:05');
+    });
+
+    it('formats long durations as hh:mm:ss', () => {
+      expect(formatStopwatchTime(3723)).toBe('01:02:03');
+    });
+
+    it('parses mm:ss back to seconds', () => {
+      expect(parseStopwatchTimeToSeconds('01:05')).toBe(65);
+    });
+
+    it('parses hh:mm:ss back to seconds', () => {
+      expect(parseStopwatchTimeToSeconds('01:02:03')).toBe(3723);
+    });
+
+    it('returns zero for invalid or empty timer text', () => {
+      expect(parseStopwatchTimeToSeconds('')).toBe(0);
+      expect(parseStopwatchTimeToSeconds('abc')).toBe(0);
+    });
+  });
+});

--- a/src/utils/sectionScore.test.js
+++ b/src/utils/sectionScore.test.js
@@ -53,6 +53,14 @@ describe('sectionScore helpers', () => {
     it('preserves manual text and appends auto suffix', () => {
       expect(buildSectionScoreValue('Manual note', '00:05', 5)).toBe('Manual note [auto: 00:05 / 5]');
     });
+
+    it('keeps empty manual text from producing extra whitespace', () => {
+      expect(buildSectionScoreValue('', '12:34', 2)).toBe('[auto: 12:34 / 2]');
+    });
+
+    it('returns empty string when both manual and auto values are empty', () => {
+      expect(buildSectionScoreValue('', '', 0)).toBe('');
+    });
   });
 
   describe('stopwatch formatting/parsing', () => {
@@ -75,6 +83,11 @@ describe('sectionScore helpers', () => {
     it('returns zero for invalid or empty timer text', () => {
       expect(parseStopwatchTimeToSeconds('')).toBe(0);
       expect(parseStopwatchTimeToSeconds('abc')).toBe(0);
+    });
+
+    it('round-trips timer text through format and parse', () => {
+      const seconds = 754;
+      expect(parseStopwatchTimeToSeconds(formatStopwatchTime(seconds))).toBe(seconds);
     });
   });
 });


### PR DESCRIPTION
## Summary
- add a per-section focus mode launched from a small play button on each section
- show a clean fullscreen section-only workout view
- include an in-card stopwatch with start/pause and reset
- include a tappable rounds card with a small reset icon

## Validation
- npm run build
