### PR TITLE
fix: improve desktop layout width and alignment

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -5,10 +5,17 @@
   color-scheme: light dark;
   color: rgba(255, 255, 255, 0.87);
   background-color: #242424;
+  --app-max-width: 800px;
+}
+
+@media (min-width: 1024px) {
+  :root {
+    --app-max-width: 1120px;
+  }
 }
 
 .app-container {
-  max-width: 800px;
+  max-width: var(--app-max-width);
   margin: 0 auto;
   padding: 1rem;
   text-align: center;
@@ -31,7 +38,7 @@ header {
   left: 50%;
   transform: translateX(-50%);
   width: 100%;
-  max-width: 800px;
+  max-width: var(--app-max-width);
   z-index: 1000;
   display: flex;
   justify-content: space-between;
@@ -58,7 +65,7 @@ main {
   flex: 1;
   padding-top: 80px;
   padding-bottom: 60px;
-  max-width: 800px;
+  max-width: var(--app-max-width);
   margin: 0 auto;
   width: 100%;
 }
@@ -75,7 +82,7 @@ footer {
   left: 50%;
   transform: translateX(-50%);
   width: 100%;
-  max-width: 800px;
+  max-width: var(--app-max-width);
   z-index: 1000;
   background-color: #242424;
   border-top: 1px solid #333;

--- a/src/index.css
+++ b/src/index.css
@@ -24,9 +24,14 @@ a:hover {
 
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
   min-width: 320px;
+  min-height: 100vh;
+  width: 100%;
+  background-color: #242424;
+}
+
+#app {
+  width: 100%;
   min-height: 100vh;
 }
 


### PR DESCRIPTION
## Summary
- introduce a shared app max-width CSS variable for the app shell
- widen the desktop layout at >=1024px while keeping mobile sizing unchanged
- make body/#app span the full viewport so the shell centers cleanly on desktop

Closes #60

## Testing
- npm run test:unit
- npm run build