### PR TITLE
feat: show session time left in account menu

### DIFF
--- a/src/app.jsx
+++ b/src/app.jsx
@@ -3,6 +3,7 @@ import Auth from './components/auth';
 import WorkoutLog from './components/workoutLog';
 import Landing from './components/landing';
 import { useWakeLock } from './hooks/useWakeLock';
+import { formatSessionTimeLeft } from './utils/authToken';
 import './app.css';
 
 const gapi = window.gapi;
@@ -13,6 +14,8 @@ const getCurrentRoute = () => `${window.location.pathname}${window.location.sear
 
 export function App() {
   const [accessToken, setAccessToken] = useState(null);
+  const [authExpiresAt, setAuthExpiresAt] = useState(null);
+  const [authNow, setAuthNow] = useState(Date.now());
   const [forceLogoutVersion, setForceLogoutVersion] = useState(0);
   const [authUiMessage, setAuthUiMessage] = useState('');
   const [isGapiLoaded, setIsGapiLoaded] = useState(false);
@@ -98,6 +101,16 @@ export function App() {
       document.removeEventListener('touchstart', handleOutsideClick);
     };
   }, []);
+
+  useEffect(() => {
+    if (!accessToken || !authExpiresAt) return undefined;
+
+    setAuthNow(Date.now());
+    const timer = setInterval(() => setAuthNow(Date.now()), 60000);
+    return () => clearInterval(timer);
+  }, [accessToken, authExpiresAt]);
+
+  const sessionTimeLeft = formatSessionTimeLeft(authExpiresAt, authNow);
 
   // Detect if running as standalone PWA
   useEffect(() => {
@@ -300,8 +313,10 @@ export function App() {
      return () => clearInterval(checkGapiReady);
   }, []);
 
-  const handleAuthChange = (token) => {
+  const handleAuthChange = (token, expiresAt = null) => {
     setAccessToken(token);
+    setAuthExpiresAt(expiresAt);
+    setAuthNow(Date.now());
     if (token) {
       setAuthUiMessage('');
     }
@@ -775,7 +790,19 @@ export function App() {
                         borderBottom: '1px solid #333',
                         marginBottom: '6px'
                       }}>
-                        {authToken ? (userName || authUserName || 'Logged in') : 'Guest'}
+                        <div>{authToken ? (userName || authUserName || 'Logged in') : 'Guest'}</div>
+                        {authToken && sessionTimeLeft && (
+                          <div
+                            title={authExpiresAt ? `Session expires at ${new Date(authExpiresAt).toLocaleTimeString()}` : undefined}
+                            style={{
+                              marginTop: '0.25em',
+                              fontSize: '0.9em',
+                              color: sessionTimeLeft === 'expired' ? '#ff9800' : '#bbb'
+                            }}
+                          >
+                            Session: {sessionTimeLeft}
+                          </div>
+                        )}
                       </div>
                       {sheetId && (
                         <button

--- a/src/components/auth.jsx
+++ b/src/components/auth.jsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'preact/hooks';
+import { TOKEN_EXPIRES_AT_KEY, getJwtExpiresAt, getTokenResponseExpiresAt } from '../utils/authToken';
 
 const STORAGE_KEY = 'google_access_token';
 const USER_NAME_KEY = 'google_user_name';
@@ -12,6 +13,7 @@ const Auth = ({ accessToken, onAuthChange, onUserNameChange, onReadyStateChange,
     setUserName(null);
     if (onUserNameChange) onUserNameChange(null);
     localStorage.removeItem(STORAGE_KEY);
+    localStorage.removeItem(TOKEN_EXPIRES_AT_KEY);
     localStorage.removeItem(USER_NAME_KEY);
     if (clearStoredEmail) {
       localStorage.removeItem(USER_EMAIL_KEY);
@@ -22,9 +24,19 @@ const Auth = ({ accessToken, onAuthChange, onUserNameChange, onReadyStateChange,
   useEffect(() => {
     const storedToken = localStorage.getItem(STORAGE_KEY);
     const storedUserName = localStorage.getItem(USER_NAME_KEY);
+    const storedExpiresAt = Number(localStorage.getItem(TOKEN_EXPIRES_AT_KEY));
+    const expiresAt = Number.isFinite(storedExpiresAt) && storedExpiresAt > 0
+      ? storedExpiresAt
+      : getJwtExpiresAt(storedToken);
+
     if (storedToken) {
+      if (expiresAt && expiresAt <= Date.now()) {
+        clearAuthState({ clearStoredEmail: false });
+        return;
+      }
+
       console.log('Restored token from localStorage');
-      onAuthChange(storedToken);
+      onAuthChange(storedToken, expiresAt);
       if (storedUserName) {
         setUserName(storedUserName);
         if (onUserNameChange) onUserNameChange(storedUserName);
@@ -43,8 +55,15 @@ const Auth = ({ accessToken, onAuthChange, onUserNameChange, onReadyStateChange,
           callback: async (tokenResponse) => {
             console.log('Token response received:', tokenResponse);
             if (tokenResponse && tokenResponse.access_token) {
+              const expiresAt = getTokenResponseExpiresAt(tokenResponse.access_token, tokenResponse);
+
               localStorage.setItem(STORAGE_KEY, tokenResponse.access_token);
-              onAuthChange(tokenResponse.access_token);
+              if (expiresAt) {
+                localStorage.setItem(TOKEN_EXPIRES_AT_KEY, String(expiresAt));
+              } else {
+                localStorage.removeItem(TOKEN_EXPIRES_AT_KEY);
+              }
+              onAuthChange(tokenResponse.access_token, expiresAt);
 
               try {
                 const userInfoResponse = await fetch('https://www.googleapis.com/oauth2/v2/userinfo', {

--- a/src/utils/authToken.js
+++ b/src/utils/authToken.js
@@ -1,0 +1,44 @@
+export const TOKEN_EXPIRES_AT_KEY = 'google_access_token_expires_at';
+
+export function decodeJwtPayload(token) {
+  if (!token || typeof token !== 'string') return null;
+
+  const parts = token.split('.');
+  if (parts.length < 2) return null;
+
+  try {
+    const base64 = parts[1].replace(/-/g, '+').replace(/_/g, '/');
+    const padded = base64.padEnd(base64.length + ((4 - (base64.length % 4)) % 4), '=');
+    const json = atob(padded);
+    return JSON.parse(json);
+  } catch {
+    return null;
+  }
+}
+
+export function getJwtExpiresAt(token) {
+  const payload = decodeJwtPayload(token);
+  return Number.isFinite(payload?.exp) ? payload.exp * 1000 : null;
+}
+
+export function getTokenResponseExpiresAt(accessToken, tokenResponse, now = Date.now()) {
+  const jwtExpiresAt = getJwtExpiresAt(accessToken);
+  if (jwtExpiresAt) return jwtExpiresAt;
+
+  const expiresIn = Number(tokenResponse?.expires_in);
+  return Number.isFinite(expiresIn) && expiresIn > 0 ? now + expiresIn * 1000 : null;
+}
+
+export function formatSessionTimeLeft(expiresAt, now = Date.now()) {
+  if (!expiresAt) return '';
+
+  const remainingMs = expiresAt - now;
+  if (remainingMs <= 0) return 'expired';
+
+  const totalMinutes = Math.ceil(remainingMs / 60000);
+  if (totalMinutes < 60) return `${totalMinutes}m left`;
+
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+  return minutes ? `${hours}h ${minutes}m left` : `${hours}h left`;
+}

--- a/src/utils/authToken.test.js
+++ b/src/utils/authToken.test.js
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import {
+  decodeJwtPayload,
+  getJwtExpiresAt,
+  getTokenResponseExpiresAt,
+  formatSessionTimeLeft,
+} from './authToken';
+
+const base64Url = (value) => Buffer.from(JSON.stringify(value))
+  .toString('base64')
+  .replace(/=/g, '')
+  .replace(/\+/g, '-')
+  .replace(/\//g, '_');
+
+const makeJwt = (payload) => `${base64Url({ alg: 'none' })}.${base64Url(payload)}.`;
+
+describe('authToken utilities', () => {
+  it('decodes a JWT payload', () => {
+    const token = makeJwt({ exp: 123, name: 'Filipe' });
+
+    expect(decodeJwtPayload(token)).toEqual({ exp: 123, name: 'Filipe' });
+  });
+
+  it('returns null for opaque or malformed tokens', () => {
+    expect(decodeJwtPayload('opaque-token')).toBeNull();
+    expect(getJwtExpiresAt('opaque-token')).toBeNull();
+  });
+
+  it('reads expiry from JWT exp first', () => {
+    const token = makeJwt({ exp: 200 });
+
+    expect(getTokenResponseExpiresAt(token, { expires_in: 3600 }, 1000)).toBe(200000);
+  });
+
+  it('falls back to expires_in for non-JWT tokens', () => {
+    expect(getTokenResponseExpiresAt('opaque-token', { expires_in: 3600 }, 1000)).toBe(3601000);
+  });
+
+  it('formats session time left', () => {
+    expect(formatSessionTimeLeft(null, 0)).toBe('');
+    expect(formatSessionTimeLeft(1000, 1000)).toBe('expired');
+    expect(formatSessionTimeLeft(30 * 60 * 1000, 0)).toBe('30m left');
+    expect(formatSessionTimeLeft(90 * 60 * 1000, 0)).toBe('1h 30m left');
+    expect(formatSessionTimeLeft(2 * 60 * 60 * 1000, 0)).toBe('2h left');
+  });
+});


### PR DESCRIPTION
## Summary
- derive auth expiry from JWT `exp` when available, falling back to Google `expires_in`
- store token expiry alongside the access token and clear expired restored tokens
- show remaining session time in the account dropdown, refreshing every minute

## Validation
- `npm run test:unit -- src/utils/authToken.test.js src/app.test.js`
- `npm run build`