### PR TITLE
feat: add renew session menu action

### DIFF
--- a/src/app.jsx
+++ b/src/app.jsx
@@ -831,6 +831,28 @@ export function App() {
                           role="menuitem"
                           onClick={() => {
                             setTopMenuOpen(false);
+                            login({ forcePrompt: true });
+                          }}
+                          style={{
+                            width: '100%',
+                            textAlign: 'left',
+                            padding: '0.65em 0.7em',
+                            fontSize: '0.9em',
+                            backgroundColor: 'transparent',
+                            color: '#fff',
+                            border: 'none',
+                            borderRadius: '6px',
+                            cursor: 'pointer'
+                          }}
+                        >
+                          Renew session
+                        </button>
+                      )}
+                      {authToken && (
+                        <button
+                          role="menuitem"
+                          onClick={() => {
+                            setTopMenuOpen(false);
                             logout();
                           }}
                           style={{

--- a/src/components/auth.jsx
+++ b/src/components/auth.jsx
@@ -105,13 +105,14 @@ const Auth = ({ accessToken, onAuthChange, onUserNameChange, onReadyStateChange,
     };
   }, []);
 
-  const handleLogin = () => {
+  const handleLogin = ({ forcePrompt = false } = {}) => {
     console.log('Login button clicked');
     console.log('Token client available:', !!tokenClient);
     if (tokenClient) {
       const loginHint = localStorage.getItem(USER_EMAIL_KEY);
-      console.log('Requesting access token...', loginHint ? 'with login_hint and prompt=""' : 'with prompt="" and without login_hint');
-      tokenClient.requestAccessToken(loginHint ? { login_hint: loginHint, prompt: '' } : { prompt: '' });
+      const prompt = forcePrompt ? 'consent' : '';
+      console.log('Requesting access token...', loginHint ? `with login_hint and prompt="${prompt}"` : `with prompt="${prompt}" and without login_hint`);
+      tokenClient.requestAccessToken(loginHint ? { login_hint: loginHint, prompt } : { prompt });
     } else {
       console.error('Token client not initialized');
     }


### PR DESCRIPTION
## Summary
- add a "Renew session" action between Sheets and Log Out in the account dropdown
- reuse the login flow with an explicit Google consent prompt to force a fresh access token

## Validation
- `npm run test:unit -- src/utils/authToken.test.js src/app.test.js`
- `npm run build`