### PR TITLE
fix: renew session without consent prompt

### DIFF
--- a/src/app.jsx
+++ b/src/app.jsx
@@ -831,7 +831,7 @@ export function App() {
                           role="menuitem"
                           onClick={() => {
                             setTopMenuOpen(false);
-                            login({ forcePrompt: true });
+                            login();
                           }}
                           style={{
                             width: '100%',

--- a/src/components/auth.jsx
+++ b/src/components/auth.jsx
@@ -105,14 +105,13 @@ const Auth = ({ accessToken, onAuthChange, onUserNameChange, onReadyStateChange,
     };
   }, []);
 
-  const handleLogin = ({ forcePrompt = false } = {}) => {
+  const handleLogin = () => {
     console.log('Login button clicked');
     console.log('Token client available:', !!tokenClient);
     if (tokenClient) {
       const loginHint = localStorage.getItem(USER_EMAIL_KEY);
-      const prompt = forcePrompt ? 'consent' : '';
-      console.log('Requesting access token...', loginHint ? `with login_hint and prompt="${prompt}"` : `with prompt="${prompt}" and without login_hint`);
-      tokenClient.requestAccessToken(loginHint ? { login_hint: loginHint, prompt } : { prompt });
+      console.log('Requesting access token...', loginHint ? 'with login_hint and prompt=""' : 'with prompt="" and without login_hint');
+      tokenClient.requestAccessToken(loginHint ? { login_hint: loginHint, prompt: '' } : { prompt: '' });
     } else {
       console.error('Token client not initialized');
     }


### PR DESCRIPTION
## Summary
- make Renew session use the same silent token request as the normal login button after expiry
- remove the explicit `prompt: 'consent'` path that caused the Google prompt to appear

## Validation
- `npm run test:unit -- src/utils/authToken.test.js src/app.test.js`
- `npm run build`